### PR TITLE
[Feat] 주변 장소정보, 장소의 모든 스팟 정보 READ 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.hibernate.orm:hibernate-spatial'
+	implementation 'com.querydsl:querydsl-spatial'
+	implementation 'org.locationtech.jts:jts-core:1.18.2'
+	implementation 'mysql:mysql-connector-java:8.0.32'
 
 	//Querydsl 추가
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/trendravel/photoravel_be/db/location/Location.java
+++ b/src/main/java/trendravel/photoravel_be/db/location/Location.java
@@ -3,10 +3,13 @@ package trendravel.photoravel_be.db.location;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import trendravel.photoravel_be.db.BaseEntity;
 import trendravel.photoravel_be.domain.location.dto.request.LocationRequestDto;
 import trendravel.photoravel_be.db.review.Review;
 import trendravel.photoravel_be.db.spot.Spot;
+import org.locationtech.jts.geom.Point;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +34,8 @@ public class Location extends BaseEntity {
     private String description;
     private String name;
 
-
+    @Column(columnDefinition = "POINT SRID 4326", nullable = false)
+    private Point point;
 
     @ElementCollection
     @CollectionTable(
@@ -59,6 +63,9 @@ public class Location extends BaseEntity {
         this.description = location.getDescription();
         this.name = location.getName();
         this.images = images;
+        this.point = new GeometryFactory()
+                .createPoint(new Coordinate(latitude, longitude));
+        this.point.setSRID(4326);
     }
 
     public void updateLocation(LocationRequestDto location){
@@ -67,6 +74,9 @@ public class Location extends BaseEntity {
         this.address = location.getAddress();
         this.description = location.getDescription();
         this.name = location.getName();
+        this.point = new GeometryFactory()
+                .createPoint(new Coordinate(latitude, longitude));
+        this.point.setSRID(4326);
     }
 
     public void increaseViews(){

--- a/src/main/java/trendravel/photoravel_be/db/respository/location/LocationRepositoryCustom.java
+++ b/src/main/java/trendravel/photoravel_be/db/respository/location/LocationRepositoryCustom.java
@@ -1,6 +1,7 @@
 package trendravel.photoravel_be.db.respository.location;
 
 import trendravel.photoravel_be.db.location.Location;
+import trendravel.photoravel_be.domain.location.dto.request.LocationKeywordDto;
 import trendravel.photoravel_be.domain.location.dto.request.LocationNowPositionDto;
 import trendravel.photoravel_be.domain.review.dto.response.RecentReviewsDto;
 
@@ -10,5 +11,6 @@ public interface LocationRepositoryCustom {
 
     List<RecentReviewsDto> recentReviews(Long id);
     List<Location> searchNowPosition(LocationNowPositionDto locationNowPositionDto);
+    List<Location> searchKeyword(LocationKeywordDto locationKeywordDto);
 
 }

--- a/src/main/java/trendravel/photoravel_be/db/respository/location/LocationRepositoryCustom.java
+++ b/src/main/java/trendravel/photoravel_be/db/respository/location/LocationRepositoryCustom.java
@@ -1,5 +1,7 @@
 package trendravel.photoravel_be.db.respository.location;
 
+import trendravel.photoravel_be.db.location.Location;
+import trendravel.photoravel_be.domain.location.dto.request.LocationNowPositionDto;
 import trendravel.photoravel_be.domain.review.dto.response.RecentReviewsDto;
 
 import java.util.List;
@@ -7,5 +9,6 @@ import java.util.List;
 public interface LocationRepositoryCustom {
 
     List<RecentReviewsDto> recentReviews(Long id);
+    List<Location> searchNowPosition(LocationNowPositionDto locationNowPositionDto);
 
 }

--- a/src/main/java/trendravel/photoravel_be/db/respository/location/LocationRepositoryImpl.java
+++ b/src/main/java/trendravel/photoravel_be/db/respository/location/LocationRepositoryImpl.java
@@ -1,14 +1,22 @@
 package trendravel.photoravel_be.db.respository.location;
 
+import com.querydsl.core.types.dsl.BooleanTemplate;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.db.review.Review;
+import trendravel.photoravel_be.domain.location.dto.request.LocationNowPositionDto;
 import trendravel.photoravel_be.domain.review.dto.response.RecentReviewsDto;
 
 
 import java.util.List;
 
 
+import static java.util.Objects.isNull;
 import static trendravel.photoravel_be.db.location.QLocation.location;
 import static trendravel.photoravel_be.db.review.QReview.review;
 
@@ -17,6 +25,10 @@ public class LocationRepositoryImpl implements LocationRepositoryCustom{
 
     private final JPAQueryFactory queryFactory;
 
+
+    /**
+     * 성능 최적화를 위한 fetch join 리팩토링 고민할 것
+     */
     @Override
     public List<RecentReviewsDto> recentReviews(Long id) {
         List<Review> recentReviews = queryFactory
@@ -29,7 +41,35 @@ public class LocationRepositoryImpl implements LocationRepositoryCustom{
                 .fetch();
 
         return recentReviews.stream()
-                .map(p -> new RecentReviewsDto(p.getContent(), p.getRating(), p.getImages()))
+                .map(p -> new RecentReviewsDto(p.getContent(),
+                        p.getRating(), p.getImages()))
                 .toList();
     }
+
+    @Override
+    public List<Location> searchNowPosition(
+            LocationNowPositionDto locationNowPositionDto) {
+        return queryFactory
+                .select(location)
+                .from(location)
+                .where(inRangeDistance(locationNowPositionDto))
+                .fetch();
+
+    }
+
+    private BooleanTemplate inRangeDistance(
+            LocationNowPositionDto locationNowPositionDto) {
+        Point points = new GeometryFactory()
+                .createPoint(new Coordinate(locationNowPositionDto.getLatitude()
+                        , locationNowPositionDto.getLongitude()));
+
+        if(isNull(points)){
+            return null;
+        }
+        points.setSRID(4326);
+
+        return Expressions.booleanTemplate("ST_Contains(ST_BUFFER({0}, {1}), {2})",
+                points, locationNowPositionDto.getRange(), location.point);
+    }
+
 }

--- a/src/main/java/trendravel/photoravel_be/domain/location/controller/LocationController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/controller/LocationController.java
@@ -8,7 +8,9 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.response.Api;
 import trendravel.photoravel_be.commom.response.Result;
+import trendravel.photoravel_be.domain.location.dto.request.LocationNowPositionDto;
 import trendravel.photoravel_be.domain.location.dto.request.LocationRequestDto;
+import trendravel.photoravel_be.domain.location.dto.response.LocationMultiReadResponseDto;
 import trendravel.photoravel_be.domain.location.dto.response.LocationResponseDto;
 import trendravel.photoravel_be.domain.location.dto.response.LocationSingleReadResponseDto;
 import trendravel.photoravel_be.domain.location.service.LocationService;
@@ -50,6 +52,21 @@ public class LocationController {
                                                            Long locationId){
         return Api.READ(locationService.readSingleLocation(locationId));
     }
+
+    @GetMapping(value = "/nowPosition")
+    public Api<List<LocationMultiReadResponseDto>> locationMultiRead(
+            @RequestParam("latitude") double latitude,
+            @RequestParam("longitude") double longitude,
+            @RequestParam("range") double range){
+
+        return Api.READ(locationService.readMultiLocation(
+                new LocationNowPositionDto(
+                        latitude, longitude, range
+                )
+        ));
+    }
+
+
 
 
     @Schema(description = "장소 수정 요청 (이미지 미포함)",

--- a/src/main/java/trendravel/photoravel_be/domain/location/controller/LocationController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/controller/LocationController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.response.Api;
 import trendravel.photoravel_be.commom.response.Result;
+import trendravel.photoravel_be.domain.location.dto.request.LocationKeywordDto;
 import trendravel.photoravel_be.domain.location.dto.request.LocationNowPositionDto;
 import trendravel.photoravel_be.domain.location.dto.request.LocationRequestDto;
 import trendravel.photoravel_be.domain.location.dto.response.LocationMultiReadResponseDto;
@@ -62,6 +63,21 @@ public class LocationController {
         return Api.READ(locationService.readMultiLocation(
                 new LocationNowPositionDto(
                         latitude, longitude, range
+                )
+        ));
+    }
+
+
+    @GetMapping(value = "/search/location")
+    public Api<List<LocationMultiReadResponseDto>> locationMultiRead(
+            @RequestParam("latitude") double latitude,
+            @RequestParam("longitude") double longitude,
+            @RequestParam("range") double range,
+            @RequestParam("keyword") String keyword){
+
+        return Api.READ(locationService.readMultiLocation(
+                new LocationKeywordDto(
+                        latitude, longitude, range, keyword
                 )
         ));
     }

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/request/LocationKeywordDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/request/LocationKeywordDto.java
@@ -1,0 +1,16 @@
+package trendravel.photoravel_be.domain.location.dto.request;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LocationKeywordDto {
+
+    private double latitude;
+    private double longitude;
+    private double range;
+    private String keyword;
+
+}

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/request/LocationNowPositionDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/request/LocationNowPositionDto.java
@@ -1,9 +1,11 @@
 package trendravel.photoravel_be.domain.location.dto.request;
 
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
+@AllArgsConstructor
 public class LocationNowPositionDto {
 
     private double latitude;

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/request/LocationNowPositionDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/request/LocationNowPositionDto.java
@@ -1,0 +1,13 @@
+package trendravel.photoravel_be.domain.location.dto.request;
+
+
+import lombok.Data;
+
+@Data
+public class LocationNowPositionDto {
+
+    private double latitude;
+    private double longitude;
+    private double range;
+
+}

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/request/LocationNowPositionDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/request/LocationNowPositionDto.java
@@ -3,9 +3,11 @@ package trendravel.photoravel_be.domain.location.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class LocationNowPositionDto {
 
     private double latitude;

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationMultiReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationMultiReadResponseDto.java
@@ -2,6 +2,7 @@ package trendravel.photoravel_be.domain.location.dto.response;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,6 +11,7 @@ import java.util.List;
 
 @Data
 @Builder
+@AllArgsConstructor
 public class LocationMultiReadResponseDto {
 
     @Schema(description = "장소ID")
@@ -37,8 +39,8 @@ public class LocationMultiReadResponseDto {
     // private List<RecentReviewsDto> recentReviewDtos;
 
     @Schema(description = "장소 생성일")
-    private LocalDateTime createdTime;
+    private LocalDateTime createAt;
     @Schema(description = "장소 수정일")
-    private LocalDateTime updatedTime;
+    private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationMultiReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationMultiReadResponseDto.java
@@ -1,0 +1,44 @@
+package trendravel.photoravel_be.domain.location.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class LocationMultiReadResponseDto {
+
+    @Schema(description = "장소ID")
+    private Long LocationId;
+    @Schema(description = "위도")
+    private double latitude;
+    @Schema(description = "경도")
+    private double longitude;
+    @Schema(description = "주소")
+    private String address;
+    @Schema(description = "장소 설명")
+    private String description;
+    @Schema(description = "장소명")
+    private String name;
+    @Schema(description = "장소 이미지들")
+    private List<String> images;
+
+    private int views;
+
+    private String ratingAvg;
+
+    //유저 객체 추가 필요
+
+    // 프론트엔드측과 의논 후 추가 여부 결정
+    // private List<RecentReviewsDto> recentReviewDtos;
+
+    @Schema(description = "장소 생성일")
+    private LocalDateTime createdTime;
+    @Schema(description = "장소 수정일")
+    private LocalDateTime updatedTime;
+
+}

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationResponseDto.java
@@ -32,8 +32,8 @@ public class LocationResponseDto {
     //유저 객체 추가 필요
 
     @Schema(description = "장소 생성일")
-    private LocalDateTime createdTime;
+    private LocalDateTime createdAt;
     @Schema(description = "장소 수정일")
-    private LocalDateTime updatedTime;
+    private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationSingleReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationSingleReadResponseDto.java
@@ -37,8 +37,8 @@ public class LocationSingleReadResponseDto {
     private List<RecentReviewsDto> recentReviewDtos;
 
     @Schema(description = "장소 생성일")
-    private LocalDateTime createdTime;
+    private LocalDateTime createdAt;
     @Schema(description = "장소 수정일")
-    private LocalDateTime updatedTime;
+    private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
@@ -8,6 +8,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.db.review.Review;
+import trendravel.photoravel_be.domain.location.dto.request.LocationKeywordDto;
 import trendravel.photoravel_be.domain.location.dto.request.LocationNowPositionDto;
 import trendravel.photoravel_be.domain.location.dto.request.LocationRequestDto;
 import trendravel.photoravel_be.domain.location.dto.response.LocationMultiReadResponseDto;
@@ -139,6 +140,26 @@ public class LocationService {
                 )
                 .toList();
     }
+
+    @Transactional
+    public List<LocationMultiReadResponseDto> readMultiLocation(LocationKeywordDto locationKeywordDto){
+        List<Location> locations = locationRepository.searchKeyword(locationKeywordDto);
+
+        if(locations.isEmpty()){
+            //예외처리
+        }
+
+        return locations.stream()
+                .map(p -> new LocationMultiReadResponseDto(
+                        p.getId(), p.getLatitude(), p.getLongitude(),
+                        p.getAddress(), p.getDescription(), p.getName(),
+                        p.getImages(),p.getViews(),
+                        String.format("%.2f",ratingAverage(p.getReview())),
+                        p.getCreatedAt(), p.getUpdatedAt())
+                )
+                .toList();
+    }
+
 
     private double ratingAverage(List<Review> reviews) {
         double sum = 0;

--- a/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
@@ -61,8 +61,8 @@ public class LocationService {
                 .longitude(location.getLongitude())
                 .images(location.getImages())
                 .address(location.getAddress())
-                .createdTime(location.getCreatedAt())
-                .updatedTime(location.getUpdatedAt())
+                .createdAt(location.getCreatedAt())
+                .updatedAt(location.getUpdatedAt())
                 .build();
     }
 
@@ -91,8 +91,8 @@ public class LocationService {
                 .latitude(location.getLatitude())
                 .longitude(location.getLongitude())
                 .address(location.getAddress())
-                .createdTime(location.getCreatedAt())
-                .updatedTime(location.getUpdatedAt())
+                .createdAt(location.getCreatedAt())
+                .updatedAt(location.getUpdatedAt())
                 .build();
     }
 
@@ -113,8 +113,8 @@ public class LocationService {
                 .address(location.getAddress())
                 .name(location.getName())
                 .description(location.getDescription())
-                .updatedTime(location.getUpdatedAt())
-                .createdTime(location.getCreatedAt())
+                .updatedAt(location.getUpdatedAt())
+                .createdAt(location.getCreatedAt())
                 .images(location.getImages())
                 .views(location.getViews())
                 .ratingAvg(String.format("%.2f", ratingAverage(location.getReview())))
@@ -192,8 +192,8 @@ public class LocationService {
                 .longitude(location.get().getLongitude())
                 .images(location.get().getImages())
                 .address(location.get().getAddress())
-                .createdTime(location.get().getCreatedAt())
-                .updatedTime(location.get().getUpdatedAt())
+                .createdAt(location.get().getCreatedAt())
+                .updatedAt(location.get().getUpdatedAt())
                 .build();
     }
 
@@ -218,8 +218,8 @@ public class LocationService {
                 .latitude(location.get().getLatitude())
                 .longitude(location.get().getLongitude())
                 .address(location.get().getAddress())
-                .createdTime(location.get().getCreatedAt())
-                .updatedTime(location.get().getUpdatedAt())
+                .createdAt(location.get().getCreatedAt())
+                .updatedAt(location.get().getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/trendravel/photoravel_be/domain/review/dto/response/ReviewResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/dto/response/ReviewResponseDto.java
@@ -31,8 +31,8 @@ public class ReviewResponseDto {
 
     // 유저 객체 추가 필요
     @Schema(description = "리뷰 생성일")
-    private LocalDateTime createdTime;
+    private LocalDateTime createdAt;
     @Schema(description = "리뷰 수정일")
-    private LocalDateTime updatedTime;
+    private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
@@ -63,8 +63,8 @@ public class ReviewService {
                 .rating(review.getRating())
                 .content(review.getContent())
                 .reviewType(review.getReviewType().toString())
-                .createdTime(review.getCreatedAt())
-                .updatedTime(review.getUpdatedAt())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
                 .build();
     }
 
@@ -105,8 +105,8 @@ public class ReviewService {
                 .rating(review.getRating())
                 .content(review.getContent())
                 .reviewType(review.getReviewType().toString())
-                .createdTime(review.getCreatedAt())
-                .updatedTime(review.getUpdatedAt())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
                 .build();
     }
 
@@ -162,8 +162,8 @@ public class ReviewService {
                 .rating(review.get().getRating())
                 .content(review.get().getContent())
                 .reviewType(review.get().getReviewType().toString())
-                .createdTime(review.get().getCreatedAt())
-                .updatedTime(review.get().getUpdatedAt())
+                .createdAt(review.get().getCreatedAt())
+                .updatedAt(review.get().getUpdatedAt())
                 .build();
     }
 
@@ -186,8 +186,8 @@ public class ReviewService {
                 .rating(review.get().getRating())
                 .content(review.get().getContent())
                 .reviewType(review.get().getReviewType().toString())
-                .createdTime(review.get().getCreatedAt())
-                .updatedTime(review.get().getUpdatedAt())
+                .createdAt(review.get().getCreatedAt())
+                .updatedAt(review.get().getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/trendravel/photoravel_be/domain/spot/controller/SpotController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/controller/SpotController.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.response.Api;
 import trendravel.photoravel_be.commom.response.Result;
 import trendravel.photoravel_be.domain.spot.dto.request.SpotRequestDto;
+import trendravel.photoravel_be.domain.spot.dto.response.SpotMultiReadResponseDto;
 import trendravel.photoravel_be.domain.spot.dto.response.SpotResponseDto;
 import trendravel.photoravel_be.db.respository.spot.SpotRepository;
 import trendravel.photoravel_be.domain.spot.dto.response.SpotSingleReadResponseDto;
@@ -57,7 +58,11 @@ public class SpotController {
         return Api.READ(spotService.readSingleSpot(locationSearchId, spotSearchId));
     }
 
-
+    @GetMapping(value = "/location/{locationSearchId}/spots")
+    public Api<List<SpotMultiReadResponseDto>> spotMultiRead(@PathVariable("locationSearchId")
+                                                       Long locationSearchId){
+        return Api.READ(spotService.readMultiSpot(locationSearchId));
+    }
 
 
     @Schema(description = "스팟 수정 요청 (이미지 미포함)",

--- a/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotMultiReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotMultiReadResponseDto.java
@@ -1,0 +1,45 @@
+package trendravel.photoravel_be.domain.spot.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class SpotMultiReadResponseDto {
+
+    @Schema(description = "스팟 ID")
+    private Long spotId;
+    @Schema(description = "스팟 제목")
+    private String title;
+    @Schema(description = "스팟 내용")
+    private String description;
+    @Schema(description = "스팟 위도")
+    private double latitude;
+    @Schema(description = "스팟 경도")
+    private double longitude;
+    @Schema(description = "스팟 이미지들")
+    private List<String> images;
+
+    private int views;
+
+    //유저 객체 추가 필요
+
+
+    // 프론트엔드측과 의논 후 추가 여부 결정
+    //private List<RecentReviewsDto> recentReviewDtos;
+
+
+    // 유저 객체 전달 필요
+    @Schema(description = "스팟 생성일")
+    private LocalDateTime createAt;
+    @Schema(description = "스팟 수정일")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotResponseDto.java
@@ -26,8 +26,8 @@ public class SpotResponseDto {
 
     // 유저 객체 전달 필요
     @Schema(description = "스팟 생성일")
-    private LocalDateTime createdTime;
+    private LocalDateTime createdAt;
     @Schema(description = "스팟 수정일")
-    private LocalDateTime updatedTime;
+    private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotSingleReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotSingleReadResponseDto.java
@@ -37,8 +37,8 @@ public class SpotSingleReadResponseDto {
 
     // 유저 객체 전달 필요
     @Schema(description = "스팟 생성일")
-    private LocalDateTime createdTime;
+    private LocalDateTime createdAt;
     @Schema(description = "스팟 수정일")
-    private LocalDateTime updatedTime;
+    private LocalDateTime updatedAt;
 
 }

--- a/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
@@ -56,8 +56,8 @@ public class SpotService {
                 .longitude(spot.getLongitude())
                 .images(spot.getImages())
                 .title(spot.getTitle())
-                .createdTime(spot.getCreatedAt())
-                .updatedTime(spot.getUpdatedAt())
+                .createdAt(spot.getCreatedAt())
+                .updatedAt(spot.getUpdatedAt())
                 .build();
     }
 
@@ -82,8 +82,8 @@ public class SpotService {
                 .latitude(spot.getLatitude())
                 .longitude(spot.getLongitude())
                 .title(spot.getTitle())
-                .createdTime(spot.getCreatedAt())
-                .updatedTime(spot.getUpdatedAt())
+                .createdAt(spot.getCreatedAt())
+                .updatedAt(spot.getUpdatedAt())
                 .build();
     }
 
@@ -103,8 +103,8 @@ public class SpotService {
                 .spotId(spot.getId())
                 .title(spot.getTitle())
                 .description(spot.getDescription())
-                .createdTime(spot.getCreatedAt())
-                .updatedTime(spot.getUpdatedAt())
+                .createdAt(spot.getCreatedAt())
+                .updatedAt(spot.getUpdatedAt())
                 .views(spot.getViews())
                 .latitude(spot.getLatitude())
                 .longitude(spot.getLongitude())
@@ -163,8 +163,8 @@ public class SpotService {
                 .latitude(spot.get().getLatitude())
                 .longitude(spot.get().getLongitude())
                 .images(spot.get().getImages())
-                .createdTime(spot.get().getCreatedAt())
-                .updatedTime(spot.get().getUpdatedAt())
+                .createdAt(spot.get().getCreatedAt())
+                .updatedAt(spot.get().getUpdatedAt())
                 .build();
     }
 
@@ -187,8 +187,8 @@ public class SpotService {
                 .description(spot.get().getDescription())
                 .latitude(spot.get().getLatitude())
                 .longitude(spot.get().getLongitude())
-                .createdTime(spot.get().getCreatedAt())
-                .updatedTime(spot.get().getUpdatedAt())
+                .createdAt(spot.get().getCreatedAt())
+                .updatedAt(spot.get().getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
@@ -8,6 +8,7 @@ import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.db.review.Review;
 import trendravel.photoravel_be.domain.review.dto.response.RecentReviewsDto;
 import trendravel.photoravel_be.domain.spot.dto.request.SpotRequestDto;
+import trendravel.photoravel_be.domain.spot.dto.response.SpotMultiReadResponseDto;
 import trendravel.photoravel_be.domain.spot.dto.response.SpotResponseDto;
 import trendravel.photoravel_be.db.spot.Spot;
 import trendravel.photoravel_be.db.respository.location.LocationRepository;
@@ -111,6 +112,25 @@ public class SpotService {
                 .ratingAvg(String.format("%.2f", ratingAverage(spot.getReviews())))
                 .recentReviewDtos(reviews)
                 .build();
+    }
+
+    @Transactional
+    public List<SpotMultiReadResponseDto> readMultiSpot(Long locationId) {
+        List<Spot> spots = locationRepository.findById(locationId)
+                .get().getSpot();
+
+        if(spots.isEmpty()){
+            //예외처리 로직
+        }
+
+        return spots.stream()
+                .map(p -> new SpotMultiReadResponseDto(
+                        p.getId(), p.getTitle(), p.getDescription(),
+                        p.getLatitude(),p.getLongitude(),
+                        p.getImages(), p.getViews(),
+                        p.getCreatedAt(), p.getUpdatedAt()
+                ))
+                .toList();
     }
 
     private double ratingAverage(List<Review> reviews) {


### PR DESCRIPTION
# 해당 PR은 "Commits on Aug 7, 2024"부터 코드리뷰하면 됩니다

# Feat
## 구현 기능
- 현재 위치 + 범위 기반 주변 장소 정보 READ 기능 구현
- 현재 위치 + 범위 + 검색키워드 기반 주변 장소 정보 READ 기능 구현
- 특정 장소의 모든 스팟 READ 기능 구현

## 구현 기능 추가 설명
- 현재 위치(경도, 위도, 찾는 범위)가 주어지면 해당 범위 내에 있는 모든 장소를 검색
- 범위의 단위는 미터 단위 1KM 반경내에서 찾고 싶다면 1000을 넘겨줘야 함
- 검색 키워드는 한 단어라도 들어가면 검색되도록 간단하게 구현

## 테스트 결과
### 현재 위치에서 주변 장소를 검색했을 때
- **성공**
![20240807_233236](https://github.com/user-attachments/assets/03b6f0a6-b27c-453f-9164-0a451e5a10cb)
![20240807_233243](https://github.com/user-attachments/assets/5c23978e-fc2f-4610-b455-bf1a3f01d816)
- **실패**
![20240807_233255](https://github.com/user-attachments/assets/1700aa21-0b4c-409f-b4ef-df824303673e)
![20240807_233300](https://github.com/user-attachments/assets/df86d602-fb8c-4bb5-a29c-c2b00bd08491)

### 현재 위치에서 어떤 장소를 검색했을 때
- **성공 1**
![20240807_235750](https://github.com/user-attachments/assets/49ebe26c-2ab5-4899-a6ab-f4f5b2caa0a4)
![20240807_235756](https://github.com/user-attachments/assets/99b3a107-0c2d-4d10-bcb3-403899179ddc)
- **성공 2**
![20240807_235808](https://github.com/user-attachments/assets/d116ccee-55dd-414c-bd95-5ec7c50a2ea7)
![20240807_235815](https://github.com/user-attachments/assets/b9cda220-6304-4507-88cb-7aa6dd5c33bd)

### 특정 장소의 모든 스팟 검색
![20240808_001403](https://github.com/user-attachments/assets/7a197a05-5b5e-493b-93c6-ea6d43768da2)
![20240808_001413](https://github.com/user-attachments/assets/51ac65e7-cd58-4ae9-8ae4-f92040c10256)


# Chore 
- hibernate-spatial, locationtech.jts, 공간 함수 라이브러리 빌드 추가
- mysql 빌드 추가

# Style
- dto 변수명 변경
**변경 전**
createdTime, updatedTime
**변경 후**
createdAt, updatedAt

# 다음 구현 기능 목표
- S3 이미지 업로드 기능 구현
