### PR TITLE
[Feat/Test/Fix] 도메인 서비스 별 Exception 처리 기능 구현/테스트 완료, Description 필드 타입 설정 문제 해결 

### DIFF
--- a/src/main/java/trendravel/photoravel_be/commom/error/LocationErrorCode.java
+++ b/src/main/java/trendravel/photoravel_be/commom/error/LocationErrorCode.java
@@ -1,0 +1,17 @@
+package trendravel.photoravel_be.commom.error;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum LocationErrorCode implements ErrorCodeIfs{
+
+    LOCATION_NOT_FOUND(404, "장소를 찾을 수 없음")
+    ;
+
+
+    private final Integer httpStatusCode;
+    private final String errorDescription;
+}

--- a/src/main/java/trendravel/photoravel_be/commom/error/ReviewErrorCode.java
+++ b/src/main/java/trendravel/photoravel_be/commom/error/ReviewErrorCode.java
@@ -1,0 +1,19 @@
+package trendravel.photoravel_be.commom.error;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReviewErrorCode implements ErrorCodeIfs{
+
+
+    REVIEW_NOT_FOUND(404, "리뷰를 찾을 수 없음")
+            ;
+
+
+    private final Integer httpStatusCode;
+    private final String errorDescription;
+
+}

--- a/src/main/java/trendravel/photoravel_be/commom/error/SpotErrorCode.java
+++ b/src/main/java/trendravel/photoravel_be/commom/error/SpotErrorCode.java
@@ -1,0 +1,19 @@
+package trendravel.photoravel_be.commom.error;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SpotErrorCode implements ErrorCodeIfs{
+
+    SPOT_NOT_FOUND(404, "스팟을 찾을 수 없음")
+    ;
+
+
+
+    private final Integer httpStatusCode;
+    private final String errorDescription;
+
+}

--- a/src/main/java/trendravel/photoravel_be/db/location/Location.java
+++ b/src/main/java/trendravel/photoravel_be/db/location/Location.java
@@ -32,6 +32,8 @@ public class Location extends BaseEntity {
     private double latitude;
     private double longitude;
     private String address;
+
+    @Column(columnDefinition = "TEXT")
     private String description;
     private String name;
 

--- a/src/main/java/trendravel/photoravel_be/db/review/Review.java
+++ b/src/main/java/trendravel/photoravel_be/db/review/Review.java
@@ -28,6 +28,7 @@ public class Review extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ReviewTypes reviewType;
 
+    @Column(columnDefinition = "TEXT")
     private String content;
     private double rating;
 

--- a/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
+++ b/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
@@ -27,6 +27,8 @@ public class Spot extends BaseEntity {
 
 
     private String title;
+
+    @Column(columnDefinition = "TEXT")
     private String description;
     private double latitude;
     private double longitude;

--- a/src/test/java/trendravel/photoravel_be/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/domain/review/service/ReviewServiceTest.java
@@ -1,12 +1,16 @@
 package trendravel.photoravel_be.domain.review.service;
 
 import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import trendravel.photoravel_be.commom.error.LocationErrorCode;
+import trendravel.photoravel_be.commom.error.ReviewErrorCode;
+import trendravel.photoravel_be.commom.error.SpotErrorCode;
+import trendravel.photoravel_be.commom.exception.ApiException;
 import trendravel.photoravel_be.commom.image.service.ImageService;
 import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.db.respository.location.LocationRepository;
@@ -21,11 +25,12 @@ import trendravel.photoravel_be.domain.review.dto.response.ReviewResponseDto;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 @SpringBootTest
-@Transactional
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ReviewServiceTest {
 
     @Autowired
@@ -51,7 +56,8 @@ class ReviewServiceTest {
     Review review2;
     Review review3;
     Review review4;
-
+    Long findLocationId;
+    Long findSpotId;
 
     @BeforeEach
     void before(){
@@ -64,8 +70,11 @@ class ReviewServiceTest {
                 .address("아산시 신창면 순천향로46")
                 .description("순천향대학교입니다.")
                 .views(0)
+                .point(new GeometryFactory().createPoint(
+                        new Coordinate(35.24
+                                , 46.61)))
                 .build();
-        locationRepository.save(location);
+        location.getPoint().setSRID(4326);
         spot = Spot
                 .builder()
                 .description("미디어랩스관입니다")
@@ -75,24 +84,23 @@ class ReviewServiceTest {
                 .views(0)
                 .location(location)
                 .build();
-        spotRepository.save(spot);
+        Long locationId = locationRepository.save(location).getId();
+        findLocationId = locationId;
+        Long spotId = spotRepository.save(spot).getId();
+        findSpotId = spotId;
         spot.setLocation(location);
         locationReview = Review.builder()
                 .id(1L)
                 .reviewType(ReviewTypes.LOCATION)
                 .content("우와 멋진 장소네요 ㅋㅋ")
                 .rating(3.4)
-                .locationReview(locationRepository.findById(1L).get())
                 .build();
         spotReview = Review.builder()
                 .id(2L)
                 .reviewType(ReviewTypes.SPOT)
                 .content("내 인생샷 장소임 ㄹㅇ")
                 .rating(1.4)
-                .spotReview(spotRepository.findById(1L).get())
                 .build();
-        reviewRepository.save(locationReview);
-        reviewRepository.save(spotReview);
 
         review1 = Review
                 .builder()
@@ -127,33 +135,33 @@ class ReviewServiceTest {
         review3.setSpotReview(spot);
         review4.setSpotReview(spot);
 
-        locationReviewRequestDto.setReviewId(reviewRepository.findById(1L).get().getId());
+        locationReviewRequestDto.setReviewId(locationId);
         locationReviewRequestDto.setReviewType(locationReview.getReviewType());
         locationReviewRequestDto.setContent(locationReview.getContent());
         locationReviewRequestDto.setRating(locationReview.getRating());
-        locationReviewRequestDto.setTypeId(locationReview.getLocationReview().getId());
+        locationReviewRequestDto.setTypeId(locationId);
 
-        spotReviewRequestDto.setReviewId(reviewRepository.findById(2L).get().getId());
+        spotReviewRequestDto.setReviewId(spotId);
         spotReviewRequestDto.setReviewType(spotReview.getReviewType());
         spotReviewRequestDto.setRating(spotReview.getRating());
         spotReviewRequestDto.setContent(spotReview.getContent());
-        spotReviewRequestDto.setTypeId(spotReview.getSpotReview().getId());
+        spotReviewRequestDto.setTypeId(spotId);
     }
 
     @Test
     @DisplayName("Location/Spot Review CREATE (이미지 미포함) Service가 잘 동작하는지 테스트")
+    @Transactional
+    @Order(1)
     void createReviewTest (){
-        reviewService.createReview(locationReviewRequestDto);
-        reviewService.createReview(spotReviewRequestDto);
+        Long locationId = reviewService.createReview(locationReviewRequestDto).getReviewId();
+        Long spotId = reviewService.createReview(spotReviewRequestDto).getReviewId();
+        locationReviewRequestDto.setReviewId(locationId);
+        spotReviewRequestDto.setReviewId(spotId);
 
-        Review findLocationReview = reviewRepository.findById(locationReviewRequestDto
-                .getReviewId()).orElse(null);
+        Review findLocationReview = reviewRepository.findById(locationId).get();
+        Review findSpotReview = reviewRepository.findById(spotId).get();
 
-        Review findSpotReview = reviewRepository.findById(spotReviewRequestDto
-                .getReviewId()).orElse(null);
 
-        assertThat(findLocationReview.getId())
-                .isEqualTo(locationReviewRequestDto.getReviewId());
         assertThat(findLocationReview.getReviewType())
                 .isEqualTo(locationReviewRequestDto.getReviewType());
         assertThat(findLocationReview.getContent())
@@ -163,8 +171,7 @@ class ReviewServiceTest {
         assertThat(findLocationReview.getLocationReview().getId())
                 .isEqualTo(locationReviewRequestDto.getTypeId());
 
-        assertThat(findSpotReview.getId())
-                .isEqualTo(spotReviewRequestDto.getReviewId());
+
         assertThat(findSpotReview.getReviewType())
                 .isEqualTo(spotReviewRequestDto.getReviewType());
         assertThat(findSpotReview.getContent())
@@ -177,11 +184,16 @@ class ReviewServiceTest {
 
     @Test
     @DisplayName("Location/Spot Review UPDATE (이미지 미포함) Service가 잘 동작하는지 테스트")
+    @Transactional
+    @Order(2)
     void updateReviewTest (){
-        reviewService.createReview(locationReviewRequestDto);
-        reviewService.createReview(spotReviewRequestDto);
+        Long locationId = reviewService.createReview(locationReviewRequestDto).getReviewId();
+        Long spotId = reviewService.createReview(spotReviewRequestDto).getReviewId();
+        locationReviewRequestDto.setReviewId(locationId);
+        spotReviewRequestDto.setReviewId(spotId);
         locationReviewRequestDto.setRating(2.1);
         spotReviewRequestDto.setRating(1.0);
+
         reviewService.updateReview(locationReviewRequestDto);
         reviewService.updateReview(spotReviewRequestDto);
 
@@ -191,8 +203,6 @@ class ReviewServiceTest {
         Review findSpotReview = reviewRepository.findById(spotReviewRequestDto
                 .getReviewId()).orElse(null);
 
-        assertThat(findLocationReview.getId())
-                .isEqualTo(locationReviewRequestDto.getReviewId());
         assertThat(findLocationReview.getReviewType())
                 .isEqualTo(locationReviewRequestDto.getReviewType());
         assertThat(findLocationReview.getContent())
@@ -202,8 +212,6 @@ class ReviewServiceTest {
         assertThat(findLocationReview.getLocationReview().getId())
                 .isEqualTo(locationReviewRequestDto.getTypeId());
 
-        assertThat(findSpotReview.getId())
-                .isEqualTo(spotReviewRequestDto.getReviewId());
         assertThat(findSpotReview.getReviewType())
                 .isEqualTo(spotReviewRequestDto.getReviewType());
         assertThat(findSpotReview.getContent())
@@ -217,11 +225,15 @@ class ReviewServiceTest {
 
     @Test
     @DisplayName("Location/Spot Review DELETE Service가 잘 동작하는지 테스트")
+    @Transactional
+    @Order(3)
     void deleteReviewTest (){
-        reviewService.createReview(locationReviewRequestDto);
-        reviewService.createReview(spotReviewRequestDto);
-        reviewService.deleteReview(1L);
-        reviewService.deleteReview(2L);
+        Long locationId = reviewService.createReview(locationReviewRequestDto).getReviewId();
+        Long spotId = reviewService.createReview(spotReviewRequestDto).getReviewId();
+        locationReviewRequestDto.setReviewId(locationId);
+        spotReviewRequestDto.setReviewId(spotId);
+        reviewService.deleteReview(locationId);
+        reviewService.deleteReview(spotId);
 
         Review findLocationReview = reviewRepository.findById(locationReviewRequestDto
                 .getReviewId()).orElse(null);
@@ -236,10 +248,13 @@ class ReviewServiceTest {
 
     @Test
     @DisplayName("Location Review READ Service가 잘 동작하는지 테스트")
+    @Transactional
+    @Order(4)
     void readLocationReviewsTest(){
-        List<ReviewResponseDto> reviews = reviewService.readAllLocationReview(1L);
+        Long locationId = reviewService.createReview(locationReviewRequestDto).getReviewId();
+        List<ReviewResponseDto> reviews = reviewService.readAllLocationReview(findLocationId);
 
-        assertThat(reviews.size()).isEqualTo(2);
+        assertThat(reviews.size()).isEqualTo(3);
         assertThat(reviews.get(0).getReviewType()).isEqualTo(review1.getReviewType().toString());
         assertThat(reviews.get(0).getContent()).isEqualTo(review1.getContent());
         assertEquals(reviews.get(0).getRating(),review1.getRating());
@@ -247,18 +262,93 @@ class ReviewServiceTest {
 
     @Test
     @DisplayName("Spot Review READ Service가 잘 동작하는지 테스트")
+    @Transactional
+    @Order(5)
     void readSpotReviewsTest(){
-        List<ReviewResponseDto> reviews = reviewService.readAllSpotReview(1L, 1L);
+        Long locationId = reviewService.createReview(locationReviewRequestDto).getReviewId();
+        reviewService.createReview(spotReviewRequestDto).getReviewId();
+        List<ReviewResponseDto> reviews = reviewService.readAllSpotReview(findLocationId, findSpotId);
 
-
-        assertThat(reviews.size()).isEqualTo(2);
+        assertThat(reviews.size()).isEqualTo(3);
         assertThat(reviews.get(0).getReviewType()).isEqualTo(review3.getReviewType().toString());
         assertThat(reviews.get(0).getContent()).isEqualTo(review3.getContent());
         assertEquals(reviews.get(0).getRating(),review3.getRating());
     }
 
 
+    @Test
+    @DisplayName("LOCATION REVIEW CREATE의 EXCEPTION이 잘 동작하는지 테스트")
+    @Transactional
+    @Order(6)
+    void createLocationReviewExceptionTest(){
+        locationReviewRequestDto.setTypeId(5L);
+        assertThatThrownBy(() -> reviewService.createReview(locationReviewRequestDto))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(LocationErrorCode.LOCATION_NOT_FOUND.getErrorDescription());
+    }
 
+    @Test
+    @DisplayName("SPOT REVIEW CREATE의 EXCEPTION이 잘 동작하는지 테스트")
+    @Transactional
+    @Order(7)
+    void createSpotReviewExceptionTest(){
+        spotReviewRequestDto.setTypeId(5L);
+        assertThatThrownBy(() -> reviewService.createReview(spotReviewRequestDto))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(SpotErrorCode.SPOT_NOT_FOUND.getErrorDescription());
+    }
+
+    @Test
+    @DisplayName("LOCATION REVIEW READ의 EXCEPTION이 잘 동작하는지 테스트")
+    @Transactional
+    @Order(8)
+    void readLocationReviewExceptionTest(){
+        assertThatThrownBy(() -> reviewService.readAllLocationReview(5L))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(LocationErrorCode.LOCATION_NOT_FOUND.getErrorDescription());
+    }
+
+
+    @Test
+    @DisplayName("LOCATION이 없을 때, SPOT REVIEW READ의 EXCEPTION이 잘 동작하는지 테스트")
+    @Transactional
+    @Order(9)
+    void readLocationReviewWhenEmptyLocationExceptionTest(){
+        assertThatThrownBy(() -> reviewService.readAllSpotReview(5L, 1L))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(LocationErrorCode.LOCATION_NOT_FOUND.getErrorDescription());
+    }
+
+    @Test
+    @DisplayName("SPOT이 없을 때, SPOT REVIEW READ의 EXCEPTION이 잘 동작하는지 테스트")
+    @Transactional
+    @Order(10)
+    void readSpotReviewWhenEmptySpotExceptionTest(){
+        assertThatThrownBy(() -> reviewService.readAllSpotReview(findLocationId, 5L))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(SpotErrorCode.SPOT_NOT_FOUND.getErrorDescription());
+    }
+
+    @Test
+    @DisplayName("REVIEW UPDATE의 EXCEPTION이 잘 동작하는지 테스트")
+    @Transactional
+    @Order(11)
+    void updateReviewExceptionTest(){
+        locationReviewRequestDto.setReviewId(5L);
+        assertThatThrownBy(() -> reviewService.updateReview(locationReviewRequestDto))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(ReviewErrorCode.REVIEW_NOT_FOUND.getErrorDescription());
+    }
+
+    @Test
+    @DisplayName("REVIEW DELETE의 EXCEPTION이 잘 동작하는지 테스트")
+    @Transactional
+    @Order(12)
+    void deleteReviewExceptionTest(){
+        assertThatThrownBy(() -> reviewService.deleteReview(100L))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(ReviewErrorCode.REVIEW_NOT_FOUND.getErrorDescription());
+    }
 
 
 }

--- a/src/test/java/trendravel/photoravel_be/service/LocationServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/service/LocationServiceTest.java
@@ -1,18 +1,23 @@
 package trendravel.photoravel_be.service;
 
-import jakarta.persistence.EntityManager;
+
 import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import trendravel.photoravel_be.commom.error.LocationErrorCode;
+import trendravel.photoravel_be.commom.exception.ApiException;
 import trendravel.photoravel_be.commom.image.service.ImageService;
 import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.db.respository.review.ReviewRepository;
 import trendravel.photoravel_be.db.review.Review;
 import trendravel.photoravel_be.db.review.enums.ReviewTypes;
+import trendravel.photoravel_be.domain.location.dto.request.LocationKeywordDto;
+import trendravel.photoravel_be.domain.location.dto.request.LocationNowPositionDto;
+import trendravel.photoravel_be.domain.location.dto.response.LocationMultiReadResponseDto;
 import trendravel.photoravel_be.domain.location.dto.response.LocationSingleReadResponseDto;
 import trendravel.photoravel_be.domain.location.service.LocationService;
 import trendravel.photoravel_be.domain.location.dto.request.LocationRequestDto;
@@ -23,9 +28,10 @@ import trendravel.photoravel_be.domain.review.dto.response.RecentReviewsDto;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
-@Transactional
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class LocationServiceTest {
 
     @Autowired
@@ -34,8 +40,6 @@ class LocationServiceTest {
     @Autowired
     ReviewRepository reviewRepository;
 
-    @Autowired
-    EntityManager em;
 
     @MockBean
     LocationService locationService;
@@ -44,6 +48,7 @@ class LocationServiceTest {
 
     LocationRequestDto locationRequestDto;
     Location location;
+    Location location2;
     Review review1;
     Review review2;
     Review review3;
@@ -60,8 +65,24 @@ class LocationServiceTest {
                 .address("아산시 신창면 순천향로46")
                 .description("순천향대학교입니다.")
                 .views(0)
+                .point(new GeometryFactory().createPoint(
+                        new Coordinate(35.24
+                                , 46.61)))
                 .build();
-        locationRepository.save(location);
+        location.getPoint().setSRID(4326);
+        location2 = Location
+                .builder()
+                .name("경찰대학교")
+                .latitude(35.22)
+                .longitude(46.59)
+                .address("아산시 경찰면 경찰로36")
+                .description("경찰대학교입니다..")
+                .views(0)
+                .point(new GeometryFactory().createPoint(
+                        new Coordinate(35.22, 46.59)))
+                .build();
+        location2.getPoint().setSRID(4326);
+
         review1 = Review
                 .builder()
                 .reviewType(ReviewTypes.LOCATION)
@@ -95,10 +116,7 @@ class LocationServiceTest {
         review3.setLocationReview(location);
         review4.setLocationReview(location);
 
-        reviewRepository.save(review1);
-        reviewRepository.save(review2);
-        reviewRepository.save(review3);
-        reviewRepository.save(review4);
+
 
 
         locationRequestDto = new LocationRequestDto();
@@ -113,12 +131,12 @@ class LocationServiceTest {
 
     @Test
     @DisplayName("Location CREATE (이미지 미포함) 서비스가 잘 작동하는지 테스트")
+    @Transactional
+    @Order(1)
     void createLocationServiceTest(){
+
         locationService.createLocation(locationRequestDto);
 
-        assertThat(locationRepository.findById(
-                locationRequestDto.getLocationId())
-                .get().getId()).isEqualTo(1L);
         assertThat(locationRepository.findById(
                 locationRequestDto.getLocationId())
                 .get().getName()).isEqualTo("순천향대학교");
@@ -139,14 +157,14 @@ class LocationServiceTest {
 
     @Test
     @DisplayName("Location UPDATE (이미지 미포함) 서비스가 잘 작동하는지 테스트")
+    @Transactional
+    @Order(2)
     void updateLocationServiceTest(){
         locationService.createLocation(locationRequestDto);
+        locationRequestDto.setLocationId(2L);
         locationRequestDto.setName("미디어랩스");
         locationService.updateLocation(locationRequestDto);
 
-        assertThat(locationRepository.findById(
-                        locationRequestDto.getLocationId())
-                .get().getId()).isEqualTo(1L);
         assertThat(locationRepository.findById(
                         locationRequestDto.getLocationId())
                 .get().getName()).isEqualTo("미디어랩스");
@@ -166,8 +184,11 @@ class LocationServiceTest {
 
     @Test
     @DisplayName("Location DELETE 서비스가 잘 작동하는지 테스트")
+    @Transactional
+    @Order(5)
     void deleteLocationServiceTest(){
-        locationService.createLocation(locationRequestDto);
+        Long newId = locationService.createLocation(locationRequestDto).getLocationId();
+        locationRequestDto.setLocationId(newId);
         locationService.deleteLocation(locationRequestDto.getLocationId());
 
         assertThat(locationRepository.findById(locationRequestDto.getLocationId())).isEmpty();
@@ -175,20 +196,27 @@ class LocationServiceTest {
 
     @Test
     @DisplayName("Location SINGLE READ 서비스가 잘 동작하는지 테스트")
+    @Transactional
+    @Order(3)
     void readSingleLocationServiceTest(){
         //given
+        locationRepository.save(location);
+        locationRepository.save(location2);
         locationService.createLocation(locationRequestDto);
-        Location findLocation = locationRepository.findById(1L).orElse(null);
+        Location findLocation = locationRepository.findById(5L).orElse(null);
+
+        reviewRepository.save(review1);
+        reviewRepository.save(review2);
+        reviewRepository.save(review3);
+        reviewRepository.save(review4);
 
         //when
         LocationSingleReadResponseDto locationSingleReadResponseDto
-                = locationService.readSingleLocation(1L);
+                = locationService.readSingleLocation(3L);
         List<RecentReviewsDto> findRecentReviews =
                 locationSingleReadResponseDto.getRecentReviewDtos();
 
         //then
-        assertThat(locationSingleReadResponseDto.getLocationId())
-                .isEqualTo(findLocation.getId());
         assertThat(locationSingleReadResponseDto.getLatitude())
                 .isEqualTo(findLocation.getLatitude());
         assertThat(locationSingleReadResponseDto.getLongitude())
@@ -206,6 +234,87 @@ class LocationServiceTest {
                 .containsExactlyInAnyOrder(review4.getRating(),
                         review2.getRating(), review3.getRating());
     }
+
+    @DisplayName("Location MULTI READ (위치기반) 서비스가 잘 동작하는지 테스트")
+    @Test
+    @Transactional
+    @Order(4)
+    void readMultiLocationWithPositionServiceTest(){
+        locationRepository.save(location);
+        locationRepository.save(location2);
+        //given
+        LocationNowPositionDto locationNowPositionDto
+                = new LocationNowPositionDto();
+        locationNowPositionDto.setLatitude(35.23);
+        locationNowPositionDto.setLongitude(46.60);
+        locationNowPositionDto.setRange(2000);
+        //when
+        List<LocationMultiReadResponseDto> locationMultiReadResponseDto
+                = locationService.readMultiLocation(locationNowPositionDto);
+        //then
+
+        assertThat(locationMultiReadResponseDto.size()).isEqualTo(2);
+        assertThat(locationMultiReadResponseDto.get(0).getLatitude()).isEqualTo(35.24);
+        assertThat(locationMultiReadResponseDto.get(0).getLongitude()).isEqualTo(46.61);
+
+        assertThat(locationMultiReadResponseDto.get(1).getLatitude()).isEqualTo(35.22);
+        assertThat(locationMultiReadResponseDto.get(1).getLongitude()).isEqualTo(46.59);
+    }
+
+    @DisplayName("Location MULTI READ (위치기반 + 검색키워드) 서비스가 잘 동작하는지 테스트")
+    @Test
+    @Transactional
+    @Order(5)
+    void readMultiLocationWithSearchServiceTest(){
+        //given
+        locationRepository.save(location);
+        locationRepository.save(location2);
+        LocationKeywordDto locationKeywordDto
+                = new LocationKeywordDto(35.23, 46.60, 2000, "순천향대");
+        //when
+        List<LocationMultiReadResponseDto> locationMultiReadResponseDto
+                = locationService.readMultiLocation(locationKeywordDto);
+        //then
+
+        assertThat(locationMultiReadResponseDto.size()).isEqualTo(1);
+        assertThat(locationMultiReadResponseDto.get(0).getLatitude()).isEqualTo(35.24);
+        assertThat(locationMultiReadResponseDto.get(0).getLongitude()).isEqualTo(46.61);
+        assertThat(locationMultiReadResponseDto.get(0).getName()).isEqualTo("순천향대학교");
+    }
+
+
+    @DisplayName("LOCATION READ의 EXCEPTION이 잘 동작하는지 테스트")
+    @Test
+    @Transactional
+    @Order(6)
+    void readExceptionServiceTest(){
+        assertThatThrownBy( () -> locationService.readSingleLocation(3L))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(LocationErrorCode.LOCATION_NOT_FOUND.getErrorDescription());
+    }
+
+    @DisplayName("LOCATION UPDATE의 EXCEPTION이 잘 동작하는지 테스트")
+    @Test
+    @Transactional
+    @Order(7)
+    void updateExceptionServiceTest(){
+        locationRequestDto.setLocationId(3L);
+        assertThatThrownBy(() -> locationService.updateLocation(locationRequestDto))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(LocationErrorCode.LOCATION_NOT_FOUND.getErrorDescription());
+    }
+
+    @DisplayName("LOCATION DELETE의 EXCEPTION이 잘 동작하는지 테스트")
+    @Test
+    @Transactional
+    @Order(8)
+    void deleteExceptionServiceTest(){
+
+        assertThatThrownBy(() -> locationService.deleteLocation(500L))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(LocationErrorCode.LOCATION_NOT_FOUND.getErrorDescription());
+    }
+
 
 
 }

--- a/src/test/java/trendravel/photoravel_be/service/SpotServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/service/SpotServiceTest.java
@@ -3,9 +3,14 @@ package trendravel.photoravel_be.service;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.*;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import trendravel.photoravel_be.commom.error.LocationErrorCode;
+import trendravel.photoravel_be.commom.error.SpotErrorCode;
+import trendravel.photoravel_be.commom.exception.ApiException;
 import trendravel.photoravel_be.commom.image.service.ImageService;
 import trendravel.photoravel_be.db.respository.review.ReviewRepository;
 import trendravel.photoravel_be.db.review.Review;
@@ -24,10 +29,10 @@ import trendravel.photoravel_be.db.respository.spot.SpotRepository;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@Transactional
 class SpotServiceTest {
 
     @Autowired
@@ -66,10 +71,12 @@ class SpotServiceTest {
                 .latitude(35.24)
                 .longitude(46.61)
                 .address("아산시 신창면 순천향로46")
-                .description("순천향대학교입니다.")
+                .point(new GeometryFactory().createPoint(
+                        new Coordinate(35.24
+                                , 46.61)))
                 .views(0)
                 .build();
-        locationRepository.save(location);
+        location.getPoint().setSRID(4326);
         spot = Spot
                 .builder()
                 .description("미디어랩스관입니다")
@@ -79,8 +86,6 @@ class SpotServiceTest {
                 .views(0)
                 .location(location)
                 .build();
-        spot.setLocation(location);
-        spotRepository.save(spot);
         review1 = Review
                 .builder()
                 .reviewType(ReviewTypes.SPOT)
@@ -109,104 +114,109 @@ class SpotServiceTest {
                 .rating(4.5)
                 .spotReview(spot)
                 .build();
-        review1.setSpotReview(spot);
-        review2.setSpotReview(spot);
-        review3.setSpotReview(spot);
-        review4.setSpotReview(spot);
 
-        reviewRepository.save(review1);
-        reviewRepository.save(review2);
-        reviewRepository.save(review3);
-        reviewRepository.save(review4);
 
-        spotRequestDto.setSpotId(1L);
+
         spotRequestDto.setTitle("미디어랩스건물 방문");
         spotRequestDto.setDescription("미디어랩스관입니다");
         spotRequestDto.setLatitude(46.61);
         spotRequestDto.setLongitude(35.24);
-        spotRequestDto.setLocationId(locationRepository.findById(1L).get().getId());
     }
 
     @Order(1)
     @Test
     @DisplayName("Spot CREATE 서비스가 (이미지 미포함) 잘 작동하는지 테스트")
+    @Transactional
     void createLocationServiceTest(){
-        spotService.createSpot(spotRequestDto);
+        Long id = locationRepository.save(location).getId();
+        spotRequestDto.setLocationId(id);
+        Long spotId = spotService.createSpot(spotRequestDto).getSpotId();
 
         assertThat(spotRepository.findById(
-                        spotRequestDto.getSpotId())
-                .get().getId()).isEqualTo(1L);
+                       spotId)
+                .get().getTitle()).isEqualTo(spotRequestDto.getTitle());
         assertThat(spotRepository.findById(
-                spotRequestDto.getSpotId())
-                .get().getLocation().getId()).
-                isEqualTo(locationRepository.findById(1L).get().getId());
+                        spotId)
+                .get().getLatitude()).isEqualTo(spotRequestDto.getLatitude());
         assertThat(spotRepository.findById(
-                        spotRequestDto.getSpotId())
-                .get().getTitle()).isEqualTo("미디어랩스건물 방문");
+                        spotId)
+                .get().getLongitude()).isEqualTo(spotRequestDto.getLongitude());
         assertThat(spotRepository.findById(
-                        spotRequestDto.getSpotId())
-                .get().getLatitude()).isEqualTo(46.61);
-        assertThat(spotRepository.findById(
-                        spotRequestDto.getSpotId())
-                .get().getLongitude()).isEqualTo(35.24);
-        assertThat(spotRepository.findById(
-                        spotRequestDto.getSpotId())
-                .get().getDescription()).isEqualTo("미디어랩스관입니다");
+                        spotId)
+                .get().getDescription()).isEqualTo(spotRequestDto.getDescription());
 
     }
 
     @Order(2)
     @Test
     @DisplayName("Spot UPDATE 서비스가 (이미지 미포함) 잘 작동하는지 테스트")
+    @Transactional
     void updateLocationServiceTest(){
-        spotService.createSpot(spotRequestDto);
+        Long id = locationRepository.save(location).getId();
+        spotRequestDto.setLocationId(id);
+        Long spotId = spotService.createSpot(spotRequestDto).getSpotId();
+        spotRequestDto.setSpotId(spotId);
         spotRequestDto.setTitle("미디어랩스 방문 후 모습");
         spotService.updateSpot(spotRequestDto);
 
         assertThat(spotRepository.findById(
-                        spotRequestDto.getLocationId())
-                .get().getId()).isEqualTo(1L);
+                        spotId)
+                .get().getTitle()).isEqualTo(spotRequestDto.getTitle());
         assertThat(spotRepository.findById(
-                        spotRequestDto.getLocationId())
-                .get().getTitle()).isEqualTo("미디어랩스 방문 후 모습");
+                        spotId)
+                .get().getLatitude()).isEqualTo(spotRequestDto.getLatitude());
         assertThat(spotRepository.findById(
-                        spotRequestDto.getLocationId())
-                .get().getLatitude()).isEqualTo(46.61);
+                        spotId)
+                .get().getLongitude()).isEqualTo(spotRequestDto.getLongitude());
         assertThat(spotRepository.findById(
-                        spotRequestDto.getLocationId())
-                .get().getLongitude()).isEqualTo(35.24);
-        assertThat(spotRepository.findById(
-                        spotRequestDto.getLocationId())
-                .get().getDescription()).isEqualTo("미디어랩스관입니다");
+                        spotId)
+                .get().getDescription()).isEqualTo(spotRequestDto.getDescription());
     }
 
     @Order(3)
     @Test
     @DisplayName("Spot DELETE 서비스가 잘 작동하는지 테스트")
+    @Transactional
     void deleteLocationServiceTest(){
-        spotService.createSpot(spotRequestDto);
-        spotService.deleteSpot(spotRequestDto.getSpotId());
+        Long id = locationRepository.save(location).getId();
+        spotRequestDto.setLocationId(id);
+        Long spotId = spotService.createSpot(spotRequestDto).getSpotId();
 
-        assertThat(spotRepository.findById(spotRequestDto.getSpotId())).isEmpty();
+        spotService.deleteSpot(spotId);
+
+        assertThat(spotRepository.findById(spotId)).isEmpty();
     }
 
+    @Order(4)
     @Test
     @DisplayName("Spot SINGLE READ 서비스가 잘 동작하는지 테스트")
+    @Transactional
     void readSingleSpotServiceTest(){
         //given
-        spotService.readSingleSpot(location.getId(), spot.getId());
-        Spot findSpot = spotRepository.findById(spot.getId()).orElse(null);
+        Long id = locationRepository.save(location).getId();
+        spotRequestDto.setLocationId(id);
+        Long spotId = spotService.createSpot(spotRequestDto).getSpotId();
 
+        Spot findSpot = spotRepository.findById(spotId).get();
+
+        review1.setSpotReview(findSpot);
+        review2.setSpotReview(findSpot);
+        review3.setSpotReview(findSpot);
+        review4.setSpotReview(findSpot);
+
+        reviewRepository.save(review1);
+        reviewRepository.save(review2);
+        reviewRepository.save(review3);
+        reviewRepository.save(review4);
         //when
         SpotSingleReadResponseDto spotSingleReadResponseDto
-                = spotService.readSingleSpot(location.getId(), spot.getId());
+                = spotService.readSingleSpot(id, spotId);
         List<RecentReviewsDto> findRecentReviews =
                 spotSingleReadResponseDto.getRecentReviewDtos();
 
+
         //then
 
-        assertThat(spotSingleReadResponseDto.getSpotId())
-                .isEqualTo(findSpot.getId());
         assertThat(spotSingleReadResponseDto.getLatitude())
                 .isEqualTo(findSpot.getLatitude());
         assertThat(spotSingleReadResponseDto.getLongitude())
@@ -225,5 +235,60 @@ class SpotServiceTest {
                 .containsExactlyInAnyOrder(review4.getRating(),
                         review2.getRating(), review3.getRating());
     }
+
+    @Order(5)
+    @DisplayName("Location이 없을 때, SPOT CREATE의 EXCEPTION이 잘 동작하는지 테스트")
+    @Test
+    @Transactional
+    void createSpotExceptionTest(){
+        spotRequestDto.setLocationId(4L);
+        assertThatThrownBy(() -> spotService.createSpot(spotRequestDto))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(LocationErrorCode.LOCATION_NOT_FOUND.getErrorDescription());
+    }
+
+    @Order(6)
+    @DisplayName("Location이 없을 때, SPOT READ EXCEPTION이 잘 동작하는지 테스트")
+    @Test
+    @Transactional
+    void readSpotExceptionWhenEmptyLocationTest(){
+        spotRequestDto.setLocationId(4L);
+        assertThatThrownBy(() -> spotService.readSingleSpot(5L,1L))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(LocationErrorCode.LOCATION_NOT_FOUND.getErrorDescription());
+    }
+
+    @Order(7)
+    @DisplayName("Location이 있지만 SPOT이 없을 때, SPOT READ EXCEPTION이 잘 동작하는지 테스트")
+    @Test
+    @Transactional
+    void readSpotExceptionWhenEmptySpotTest(){
+        spotRequestDto.setLocationId(4L);
+        assertThatThrownBy(() -> spotService.readSingleSpot(1L,2L))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(LocationErrorCode.LOCATION_NOT_FOUND.getErrorDescription());
+    }
+
+    @Order(8)
+    @DisplayName("Spot이 없을 때, SPOT UPDATE EXCEPTION이 잘 동작하는지 테스트")
+    @Test
+    @Transactional
+    void updateSpotExceptionTest(){
+        spotRequestDto.setSpotId(4L);
+        assertThatThrownBy(() -> spotService.updateSpot(spotRequestDto))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(SpotErrorCode.SPOT_NOT_FOUND.getErrorDescription());
+    }
+
+    @Order(9)
+    @DisplayName("SPOT DELETE EXCEPTION이 잘 동작하는지 테스트")
+    @Test
+    @Transactional
+    void deleteSpotExceptionTest(){
+        assertThatThrownBy(() -> spotService.deleteSpot(100L))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(SpotErrorCode.SPOT_NOT_FOUND.getErrorDescription());
+    }
+
 
 }


### PR DESCRIPTION
# Feat
- 도메인별 에러코드 구현
- 도메인 서비스별 Exception 기능 구현

# Test
- 도메인 서비스별 Exception 기능 동작 테스트
## 테스트 결과
### Location
![20240822_010447](https://github.com/user-attachments/assets/cc3b498a-febd-420a-aaab-6f83378fee80)

### Spot
![20240822_010350](https://github.com/user-attachments/assets/1cabd1e3-7bdf-4927-9954-ea66854fa42e)

### Review
![20240822_010316](https://github.com/user-attachments/assets/ab939dbd-ecd8-4c4e-9017-8cda89279e83)


# Fix
- Description 필드 타입 설정 문제 해결
## 발생 문제
- @Lob 애노테이션 지정 시, tinytext로 지정되는 문제 발생
![20240820_223434](https://github.com/user-attachments/assets/77c041e6-0979-415f-8c1d-6a72dc1b26ce)


## 원인
- @Lob 애노테이션 사용시, mysql의 default 문자열 값인 tinytext로 지정됨

## 해결
- @Column(columnDefinition = "TEXT") 애노테이션으로 변경하여 적용 후, 해결

## 결과
- mysql 테이블 생성 시, TEXT 타입으로 저장되는 것을 확인할 수 있음
![20240820_223608](https://github.com/user-attachments/assets/7b147173-ea66-438d-8779-7c3ff4f2b2f2)

- 이제 글자 수 제한 없이 DB에 저장 가능해짐
![20240820_223626](https://github.com/user-attachments/assets/b1da9d01-c920-44e4-be1e-8513e6d9b1a9)


# 다음 목표
- 이미지 서비스 Exception 기능 구현 및 테스트
- 전체 Exception 기능 구현 및 테스트