### PR TITLE
[Feat] 멤버 CRUD, Local login 및 토큰 인증 인가 구현

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3.8'  # Docker Compose 파일 버전
+
+services:
+  redis:
+    image: redis:latest  # Redis 최신 버전 사용
+    container_name: photoravel-redis  # 컨테이너 이름
+    ports:
+      - "6379:6379"  # 호스트의 6379 포트를 컨테이너의 6379 포트와 연결
+    volumes:
+      - redis-data:/data  # 데이터 지속성을 위한 볼륨 설정
+
+volumes:
+  redis-data:  # Redis 데이터 저장을 위한 볼륨 정의

--- a/src/main/java/trendravel/photoravel_be/commom/error/MemberErrorCode.java
+++ b/src/main/java/trendravel/photoravel_be/commom/error/MemberErrorCode.java
@@ -2,6 +2,7 @@ package trendravel.photoravel_be.commom.error;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.web.client.HttpClientErrorException;
 
 @AllArgsConstructor
 @Getter
@@ -9,6 +10,9 @@ public enum MemberErrorCode implements ErrorCodeIfs{
 
     USER_NOT_FOUND(400, "유저를 찾을 수 없음"),
     EXISTS_USER(400, "이미 존재하는 회원입니다."),
+    PASSWORD_NOT_MATCH(400, "패스워드가 일치하지 않습니다."),
+    MEMBER_ID_NOT_MATCH(400, "아이디가 일치하지 않습니다."),
+    UNAUTHORIZED(401, "인증되지 않았습니다.")
     ;
 
     private final Integer httpStatusCode;

--- a/src/main/java/trendravel/photoravel_be/commom/error/TokenErrorCode.java
+++ b/src/main/java/trendravel/photoravel_be/commom/error/TokenErrorCode.java
@@ -7,9 +7,12 @@ import lombok.Getter;
 @Getter
 public enum TokenErrorCode implements ErrorCodeIfs{
 
-    INVALID_TOKEN(400, "유효하지 않은 토큰"),
-    EXPIRED_TOKEN(400, "만료된 토큰입니다."),
-    TOKEN_EXCEPTION(400, "알 수 없는 토큰 에러"),
+    // 토큰 관련 status 코드는 직접 정의한 code를 사용합니다.
+    INVALID_TOKEN(2000, "유효하지 않은 토큰"),
+    EXPIRED_TOKEN(2001, "만료된 토큰입니다."),
+    TOKEN_EXCEPTION(2002, "알 수 없는 토큰 에러"),
+    AUTHORIZATION_TOKEN_NOT_FOUND(2003, "인증 헤더 토큰 없음"),
+    REFRESH_TOKEN_NOT_VALID(2004, "저장된 리프레쉬 토큰 없음(로그인 후 이용 가능)")
     ;
 
     private final Integer httpStatusCode;

--- a/src/main/java/trendravel/photoravel_be/commom/exception/JwtException.java
+++ b/src/main/java/trendravel/photoravel_be/commom/exception/JwtException.java
@@ -1,0 +1,52 @@
+package trendravel.photoravel_be.commom.exception;
+
+import lombok.Getter;
+import trendravel.photoravel_be.commom.error.ErrorCodeIfs;
+
+@Getter
+public class JwtException extends RuntimeException{
+
+    private final ErrorCodeIfs errorCodeIfs;
+    private final String errorDescription;
+
+    public JwtException(ErrorCodeIfs errorCodeIfs){
+        super(errorCodeIfs.getErrorDescription());
+        this.errorCodeIfs = errorCodeIfs;
+        this.errorDescription = errorCodeIfs.getErrorDescription();
+    }
+
+    public JwtException(ErrorCodeIfs errorCodeIfs, Throwable cause) {
+        super(cause);
+        this.errorCodeIfs = errorCodeIfs;
+        this.errorDescription = errorCodeIfs.getErrorDescription();
+    }
+
+    public JwtException(ErrorCodeIfs errorCodeIfs, String errorDescription) {
+        this.errorCodeIfs = errorCodeIfs;
+        this.errorDescription = errorDescription;
+    }
+
+    public JwtException(String message, ErrorCodeIfs errorCodeIfs, String errorDescription) {
+        super(message);
+        this.errorCodeIfs = errorCodeIfs;
+        this.errorDescription = errorDescription;
+    }
+
+    public JwtException(String message, Throwable cause, ErrorCodeIfs errorCodeIfs, String errorDescription) {
+        super(message, cause);
+        this.errorCodeIfs = errorCodeIfs;
+        this.errorDescription = errorDescription;
+    }
+
+    public JwtException(Throwable cause, ErrorCodeIfs errorCodeIfs, String errorDescription) {
+        super(cause);
+        this.errorCodeIfs = errorCodeIfs;
+        this.errorDescription = errorDescription;
+    }
+
+    public JwtException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace, ErrorCodeIfs errorCodeIfs, String errorDescription) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        this.errorCodeIfs = errorCodeIfs;
+        this.errorDescription = errorDescription;
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/config/RedisConfig.java
+++ b/src/main/java/trendravel/photoravel_be/config/RedisConfig.java
@@ -1,0 +1,47 @@
+package trendravel.photoravel_be.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import trendravel.photoravel_be.db.inmemorydb.entity.Token;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(redisHost, redisPort);
+        configuration.setPassword(redisPassword);
+        return new LettuceConnectionFactory(configuration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Token> redisTemplate() {
+        RedisTemplate<String, Token> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer()); // JSON 직렬화기 사용
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+}
+

--- a/src/main/java/trendravel/photoravel_be/config/SecurityConfig.java
+++ b/src/main/java/trendravel/photoravel_be/config/SecurityConfig.java
@@ -1,0 +1,63 @@
+package trendravel.photoravel_be.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+
+        return http
+                .httpBasic(AbstractHttpConfigurer::disable) //rest api를 사용하므로 비활성화
+                .csrf(AbstractHttpConfigurer::disable)  // token을 사용하므로 비활성화
+                .cors(custom -> custom.configurationSource(new CorsConfigurationSource() {
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+                        CorsConfiguration config = new CorsConfiguration();
+                        config.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+                        config.setAllowedMethods(Collections.singletonList("*"));
+                        config.setAllowCredentials(true);
+                        config.setAllowedHeaders(Collections.singletonList("*"));
+                        config.setMaxAge(3600L); //1시간
+                        return config;
+                    }
+                }))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .sessionManagement(configurer -> {
+                    configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                })
+                .authorizeHttpRequests(request -> {
+                    request.requestMatchers("/swagger-ui.html").permitAll();
+                    request.requestMatchers("/swagger-ui/**").permitAll();
+                    request.requestMatchers("/v3/api-docs/**").permitAll();
+                    request.requestMatchers("/public/**").permitAll();
+                    request.requestMatchers("/login/**").permitAll();
+                    request.requestMatchers("/private/member/**").authenticated();
+                    request.anyRequest().permitAll();
+                })
+                .build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/db/inmemorydb/entity/Token.java
+++ b/src/main/java/trendravel/photoravel_be/db/inmemorydb/entity/Token.java
@@ -1,0 +1,20 @@
+package trendravel.photoravel_be.db.inmemorydb.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash(value = "token", timeToLive = 12)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class Token {
+
+    @Id
+    private String id;
+    private String refreshToken;
+}

--- a/src/main/java/trendravel/photoravel_be/db/inmemorydb/repository/TokenRepository.java
+++ b/src/main/java/trendravel/photoravel_be/db/inmemorydb/repository/TokenRepository.java
@@ -1,0 +1,9 @@
+package trendravel.photoravel_be.db.inmemorydb.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import trendravel.photoravel_be.db.inmemorydb.entity.Token;
+
+@Repository
+public interface TokenRepository extends CrudRepository<Token, String> {
+}

--- a/src/main/java/trendravel/photoravel_be/domain/authentication/service/AuthenticationService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/authentication/service/AuthenticationService.java
@@ -20,6 +20,8 @@ public class AuthenticationService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
+        // spring security 기본 설정은 username 이지만
+        // 내부 로직에서 사용하는 필드는 member의 memberId 필드입니다!!
         MemberEntity memberEntity = memberRepository.findByMemberId(username)
                 .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 유저입니다."));
 

--- a/src/main/java/trendravel/photoravel_be/domain/authentication/service/AuthenticationService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/authentication/service/AuthenticationService.java
@@ -1,0 +1,36 @@
+package trendravel.photoravel_be.domain.authentication.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import trendravel.photoravel_be.db.member.MemberEntity;
+import trendravel.photoravel_be.db.respository.member.MemberRepository;
+import trendravel.photoravel_be.domain.authentication.session.UserSession;
+
+@Service
+@RequiredArgsConstructor
+public class AuthenticationService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        MemberEntity memberEntity = memberRepository.findByMemberId(username)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 유저입니다."));
+
+        return UserSession.builder()
+                .email(memberEntity.getEmail())
+                .memberId(memberEntity.getMemberId())
+                .name(memberEntity.getName())
+                .nickname(memberEntity.getNickname())
+                .profileImg(memberEntity.getProfileImg())
+                .createdAt(memberEntity.getCreatedAt())
+                .updatedAt(memberEntity.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/domain/authentication/session/UserSession.java
+++ b/src/main/java/trendravel/photoravel_be/domain/authentication/session/UserSession.java
@@ -35,11 +35,12 @@ public class UserSession implements UserDetails {
         return password;
     }
 
-    // 메소드 명은 시큐리티 기본으로 userName이지만
-    // 실제로 내부 로직에서 사용하는 것은 email입니다.
+    // 메소드 명은 시큐리티 기본으로 username이지만
+    /** !!!! IMPORTANT !!!! **/
+    // 실제로 내부 로직에서 사용하는 것은 memberId입니다.
     @Override
     public String getUsername() {
-        return email;
+        return memberId;
     }
 
     @Override

--- a/src/main/java/trendravel/photoravel_be/domain/authentication/session/UserSession.java
+++ b/src/main/java/trendravel/photoravel_be/domain/authentication/session/UserSession.java
@@ -1,0 +1,64 @@
+package trendravel.photoravel_be.domain.authentication.session;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserSession implements UserDetails {
+
+    private String email;
+    private String password;
+    private String memberId;
+    private String name;
+    private String nickname;
+    private String profileImg;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList(); // 빈 권한 리스트
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    // 메소드 명은 시큐리티 기본으로 userName이지만
+    // 실제로 내부 로직에서 사용하는 것은 email입니다.
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/domain/member/controller/MemberPrivateController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/controller/MemberPrivateController.java
@@ -1,0 +1,38 @@
+package trendravel.photoravel_be.domain.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import trendravel.photoravel_be.commom.response.Api;
+import trendravel.photoravel_be.domain.member.dto.MemberModRequest;
+import trendravel.photoravel_be.domain.member.dto.MemberResponse;
+import trendravel.photoravel_be.domain.member.service.MemberService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/private/member")
+public class MemberPrivateController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/info/{memberId}")
+    public Api<MemberResponse> getMemberInfo(
+            @PathVariable String memberId
+    ) {
+        MemberResponse response = memberService.getMemberInfo(memberId);
+        return Api.OK(response);
+    }
+
+    @PatchMapping("/info")
+    public Api<MemberResponse> patchInfo(MemberModRequest request) {
+        MemberResponse response = memberService.memberModi(request);
+        return Api.OK(response);
+    }
+
+    @DeleteMapping("/{memberId}")
+    public Api<?> delete(
+            @PathVariable String memberId
+    ) {
+        memberService.delete(memberId);
+        return Api.OK("deleted");
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/domain/member/controller/MemberPublicController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/controller/MemberPublicController.java
@@ -4,9 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import trendravel.photoravel_be.commom.response.Api;
 import trendravel.photoravel_be.domain.member.dto.MemberInfoCheckResponse;
+import trendravel.photoravel_be.domain.member.dto.MemberLoginRequest;
 import trendravel.photoravel_be.domain.member.dto.MemberRegisterRequest;
 import trendravel.photoravel_be.domain.member.dto.MemberResponse;
 import trendravel.photoravel_be.domain.member.service.MemberService;
+import trendravel.photoravel_be.domain.token.model.TokenResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +26,13 @@ public class MemberPublicController {
         return Api.CREATED(response);
     }
 
+    @PostMapping("/local")
+    public Api<TokenResponse> localLogin(
+            @RequestBody MemberLoginRequest request
+    ) {
+        TokenResponse response = memberService.localLogin(request);
+        return Api.OK(response);
+    }
 
 
     @GetMapping("/{email}/email-check")

--- a/src/main/java/trendravel/photoravel_be/domain/member/controller/MemberPublicController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/controller/MemberPublicController.java
@@ -1,0 +1,52 @@
+package trendravel.photoravel_be.domain.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import trendravel.photoravel_be.commom.response.Api;
+import trendravel.photoravel_be.domain.member.dto.MemberInfoCheckResponse;
+import trendravel.photoravel_be.domain.member.dto.MemberRegisterRequest;
+import trendravel.photoravel_be.domain.member.dto.MemberResponse;
+import trendravel.photoravel_be.domain.member.service.MemberService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/public/member")
+public class MemberPublicController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/register")
+    public Api<MemberResponse> localRegister(
+            @RequestBody MemberRegisterRequest request
+    ) {
+        MemberResponse response = memberService.localRegister(request);
+
+        return Api.CREATED(response);
+    }
+
+
+
+    @GetMapping("/{email}/email-check")
+    public Api<MemberInfoCheckResponse> emailCheck(
+            @PathVariable String email
+    ) {
+        MemberInfoCheckResponse response = memberService.emailCheck(email);
+        return Api.OK(response);
+    }
+
+    @GetMapping("/{nickname}/nickname-check")
+    public Api<MemberInfoCheckResponse> nicknameCheck(
+            @PathVariable String nickname
+    ) {
+        MemberInfoCheckResponse response = memberService.nicknameCheck(nickname);
+        return Api.OK(response);
+    }
+
+    @GetMapping("/{memberId}/memberId-check")
+    public Api<MemberInfoCheckResponse> memberIdCheck(
+            @PathVariable String memberId
+    ) {
+        MemberInfoCheckResponse response = memberService.memberIdCheck(memberId);
+        return Api.OK(response);
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/domain/member/convertor/MemberConvertor.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/convertor/MemberConvertor.java
@@ -1,0 +1,23 @@
+package trendravel.photoravel_be.domain.member.convertor;
+
+import org.springframework.stereotype.Component;
+import trendravel.photoravel_be.db.member.MemberEntity;
+import trendravel.photoravel_be.domain.member.dto.MemberResponse;
+
+@Component
+public class MemberConvertor {
+
+
+    public MemberResponse toMemberResponse(MemberEntity saved) {
+        return MemberResponse.builder()
+                .memberId(saved.getMemberId())
+                .email(saved.getEmail())
+                .password(saved.getPassword())
+                .name(saved.getName())
+                .nickname(saved.getNickname())
+                .profileImg(saved.getProfileImg())
+                .createdAt(saved.getCreatedAt())
+                .updatedAt(saved.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/domain/member/dto/BaseMemberDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/dto/BaseMemberDto.java
@@ -1,0 +1,22 @@
+package trendravel.photoravel_be.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BaseMemberDto {
+
+    private String provider;
+    private String ID;
+    private String profileImg;
+    private String email;
+    private String nickname;
+
+    private boolean isExist;
+
+}

--- a/src/main/java/trendravel/photoravel_be/domain/member/dto/CompleteMemberDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/dto/CompleteMemberDto.java
@@ -1,0 +1,18 @@
+package trendravel.photoravel_be.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompleteMemberDto {
+
+    private String provider;
+    private String id;
+    private String name;
+    private String nickname;
+    private String email;
+    private String profileImg;
+}

--- a/src/main/java/trendravel/photoravel_be/domain/member/dto/MemberInfoCheckResponse.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/dto/MemberInfoCheckResponse.java
@@ -1,0 +1,11 @@
+package trendravel.photoravel_be.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberInfoCheckResponse {
+
+    private boolean isDuplicated;
+}

--- a/src/main/java/trendravel/photoravel_be/domain/member/dto/MemberLoginRequest.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/dto/MemberLoginRequest.java
@@ -1,0 +1,15 @@
+package trendravel.photoravel_be.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberLoginRequest {
+
+
+    private String memberId;
+    private String password;
+}

--- a/src/main/java/trendravel/photoravel_be/domain/member/dto/MemberModRequest.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/dto/MemberModRequest.java
@@ -1,0 +1,17 @@
+package trendravel.photoravel_be.domain.member.dto;
+
+import lombok.*;
+
+@Data
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberModRequest {
+
+    private String memberId;
+    private String password;
+    private String name;
+    private String nickname;
+    private String profileImg;
+}

--- a/src/main/java/trendravel/photoravel_be/domain/member/dto/MemberRegisterRequest.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/dto/MemberRegisterRequest.java
@@ -1,0 +1,18 @@
+package trendravel.photoravel_be.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberRegisterRequest {
+
+    private String memberId;
+    private String email;
+    private String password;
+    private String name;
+    private String nickname;
+    private String profileImg;
+}

--- a/src/main/java/trendravel/photoravel_be/domain/member/dto/MemberResponse.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/dto/MemberResponse.java
@@ -1,0 +1,25 @@
+package trendravel.photoravel_be.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberResponse {
+
+    private String memberId;
+    private String email;
+    private String password;
+    private String name;
+    private String nickname;
+    private String profileImg;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/trendravel/photoravel_be/domain/member/service/MemberService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/service/MemberService.java
@@ -140,7 +140,7 @@ public class MemberService {
         log.info("find member : {}, memberId : {}", member.getMemberId(), memberId);
 
         if (member.getMemberId().equals(memberId)){
-            redisTemplate.opsForHash().delete(memberId);
+            redisTemplate.opsForHash().delete("refresh_token", memberId);
             SecurityContextHolder.clearContext();
             memberRepository.delete(member);
         }else {

--- a/src/main/java/trendravel/photoravel_be/domain/member/service/MemberService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/service/MemberService.java
@@ -13,7 +13,7 @@ import trendravel.photoravel_be.commom.exception.ApiException;
 import trendravel.photoravel_be.db.inmemorydb.entity.Token;
 import trendravel.photoravel_be.db.member.MemberEntity;
 import trendravel.photoravel_be.db.respository.member.MemberRepository;
-import trendravel.photoravel_be.domain.authentication.model.UserSession;
+import trendravel.photoravel_be.domain.authentication.session.UserSession;
 import trendravel.photoravel_be.domain.member.convertor.MemberConvertor;
 import trendravel.photoravel_be.domain.member.dto.*;
 import trendravel.photoravel_be.domain.token.model.TokenDto;

--- a/src/main/java/trendravel/photoravel_be/domain/member/service/MemberService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/service/MemberService.java
@@ -1,0 +1,172 @@
+package trendravel.photoravel_be.domain.member.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import trendravel.photoravel_be.commom.error.MemberErrorCode;
+import trendravel.photoravel_be.commom.exception.ApiException;
+import trendravel.photoravel_be.db.inmemorydb.entity.Token;
+import trendravel.photoravel_be.db.member.MemberEntity;
+import trendravel.photoravel_be.db.respository.member.MemberRepository;
+import trendravel.photoravel_be.domain.authentication.model.UserSession;
+import trendravel.photoravel_be.domain.member.convertor.MemberConvertor;
+import trendravel.photoravel_be.domain.member.dto.*;
+import trendravel.photoravel_be.domain.token.model.TokenDto;
+import trendravel.photoravel_be.domain.token.model.TokenResponse;
+import trendravel.photoravel_be.domain.token.service.TokenService;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final MemberConvertor memberConvertor;
+    private final TokenService tokenService;
+    private final PasswordEncoder passwordEncoder;
+    private final RedisTemplate<String, Token> redisTemplate;
+
+    @Transactional
+    public TokenResponse login(BaseMemberDto baseMemberDto) {
+        MemberEntity member = memberRepository.findByEmail(baseMemberDto.getEmail())
+                .orElseThrow(() -> new ApiException(MemberErrorCode.USER_NOT_FOUND));
+        return issueTokenResponse(member);
+    }
+
+
+    @Transactional
+    public TokenResponse addInfoWithLogin(CompleteMemberDto memberDto) {
+
+        MemberEntity memberEntity = MemberEntity.builder()
+                .memberId(memberDto.getProvider() + "_" + memberDto.getId())
+                .password(passwordEncoder.encode(memberDto.getProvider() + "_" + memberDto.getId() + "key"))
+                .email(memberDto.getEmail())
+                .name(memberDto.getName())
+                .nickname(memberDto.getNickname())
+                .profileImg(memberDto.getProfileImg())
+                .build();
+
+        MemberEntity saved = memberRepository.save(memberEntity);
+        log.info("saved member : {}", saved.getEmail());
+
+        return issueTokenResponse(saved);
+    }
+
+    @Transactional
+    public MemberResponse localRegister(MemberRegisterRequest request) {
+        MemberEntity memberEntity = MemberEntity.builder()
+                .memberId(request.getMemberId())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .name(request.getName())
+                .nickname(request.getNickname())
+                .email(request.getEmail())
+                .profileImg(request.getProfileImg())
+                .build();
+        MemberEntity saved = memberRepository.save(memberEntity);
+
+        return memberConvertor.toMemberResponse(saved);
+    }
+
+    @Transactional
+    public MemberResponse getMemberInfo(String memberId) {
+
+        MemberEntity memberEntity = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new ApiException(MemberErrorCode.USER_NOT_FOUND));
+
+        return memberConvertor.toMemberResponse(memberEntity);
+    }
+
+    @Transactional
+    public MemberResponse memberModi(MemberModRequest request) {
+
+        // 스프링 시큐리티 컨텍스트 홀더에서 인증 객체를 찾음으로써 인증된 사용자인지 검증
+        // jwt 토큰 인증 필터를 거칠 때 홀더에 인증 객체를 저장하기 때문.
+
+        UserSession principal = (UserSession) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        MemberEntity memberEntity = memberRepository.findByEmail(principal.getUsername())
+                .orElseThrow(() -> new ApiException(MemberErrorCode.UNAUTHORIZED));
+
+        memberEntity.setMemberId(request.getMemberId());
+        memberEntity.setPassword(passwordEncoder.encode(request.getPassword()));
+        memberEntity.setName(request.getName());
+        memberEntity.setNickname(request.getNickname());
+        memberEntity.setProfileImg(request.getProfileImg());
+
+        MemberEntity saved = memberRepository.save(memberEntity);
+
+        return memberConvertor.toMemberResponse(saved);
+    }
+
+    @Transactional
+    public MemberInfoCheckResponse emailCheck(String email) {
+
+        boolean result = memberRepository.findByEmail(email).isPresent();
+
+        return MemberInfoCheckResponse.builder()
+                .isDuplicated(result)
+                .build();
+    }
+
+    @Transactional
+    public MemberInfoCheckResponse nicknameCheck(String nickname) {
+        boolean result = memberRepository.findByNickname(nickname).isPresent();
+
+        return MemberInfoCheckResponse.builder()
+                .isDuplicated(result)
+                .build();
+    }
+
+    @Transactional
+    public MemberInfoCheckResponse memberIdCheck(String memberId) {
+        boolean result = memberRepository.findByMemberId(memberId).isPresent();
+
+        return MemberInfoCheckResponse.builder()
+                .isDuplicated(result)
+                .build();
+    }
+
+    @Transactional
+    public void delete(String memberId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserSession principal = (UserSession) authentication.getPrincipal();
+
+        MemberEntity member = memberRepository.findByMemberId(principal.getUsername())
+                .orElseThrow(() -> new ApiException(MemberErrorCode.USER_NOT_FOUND));
+        log.info("find member : {}, memberId : {}", member.getMemberId(), memberId);
+
+        if (member.getMemberId().equals(memberId)){
+            redisTemplate.opsForHash().delete(memberId);
+            SecurityContextHolder.clearContext();
+            memberRepository.delete(member);
+        }else {
+            throw new ApiException(MemberErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    @Transactional
+    public TokenResponse localLogin(MemberLoginRequest request) {
+        MemberEntity memberEntity = memberRepository.findByMemberId(request.getMemberId())
+                .orElseThrow(() -> new ApiException(MemberErrorCode.MEMBER_ID_NOT_MATCH));
+        if (passwordEncoder.matches(request.getPassword(), memberEntity.getPassword())) {
+            return issueTokenResponse(memberEntity);
+        } else {
+            throw new ApiException(MemberErrorCode.PASSWORD_NOT_MATCH);
+        }
+    }
+
+
+    private TokenResponse issueTokenResponse(MemberEntity member) {
+        TokenDto accessTokenDto = tokenService.issueAccessToken(member.getEmail());
+        TokenDto refreshTokenDto = tokenService.issueRefreshToken(member.getEmail());
+
+        return TokenResponse.builder()
+                .accessToken(accessTokenDto)
+                .refreshToken(refreshTokenDto)
+                .build();
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/domain/token/helper/TokenHelper.java
+++ b/src/main/java/trendravel/photoravel_be/domain/token/helper/TokenHelper.java
@@ -1,0 +1,113 @@
+package trendravel.photoravel_be.domain.token.helper;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import trendravel.photoravel_be.commom.error.TokenErrorCode;
+import trendravel.photoravel_be.commom.exception.JwtException;
+import trendravel.photoravel_be.domain.token.model.TokenDto;
+
+import javax.crypto.SecretKey;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TokenHelper {
+
+    @Value("${token.secret.key}")
+    private String secretKey;
+
+    @Value("${token.access-token.plus-hour}")
+    private Long accessTokenPlusHour;
+
+    @Value("${token.refresh-token.plus-hour}")
+    private Long refreshTokenPlusHour;
+
+    public TokenDto issueAccessToken(Map<String, Object> data) {
+
+        LocalDateTime expiredLocalDateTime = LocalDateTime.now().plusHours(accessTokenPlusHour);
+
+        Date expiredAt = Date.from(
+                expiredLocalDateTime.atZone(
+                        ZoneId.systemDefault()
+                ).toInstant()
+        );
+
+        SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes());
+
+        String jwtToken = Jwts.builder()
+                .signWith(key, SignatureAlgorithm.HS256)
+                .setClaims(data)
+                .setExpiration(expiredAt)
+                .compact();
+
+        return TokenDto.builder()
+                .token(jwtToken)
+                .expiredAt(expiredLocalDateTime)
+                .build();
+    }
+
+    public TokenDto issueRefreshToken(Map<String, Object> data) {
+
+        LocalDateTime expiredLocalDateTime = LocalDateTime.now().plusHours(refreshTokenPlusHour);
+
+        Date expiredAt = Date.from(
+                expiredLocalDateTime.atZone(
+                        ZoneId.systemDefault()
+                ).toInstant()
+        );
+
+        SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes());
+
+        String jwtToken = Jwts.builder()
+                .signWith(key, SignatureAlgorithm.HS256)
+                .setClaims(data)
+                .setExpiration(expiredAt)
+                .compact();
+
+        return TokenDto.builder()
+                .token(jwtToken)
+                .expiredAt(expiredLocalDateTime)
+                .build();
+
+    }
+
+    public Map<String, Object> validationTokenWithThrow(String token) {
+
+        SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes());
+
+        JwtParser parser = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build();
+
+        try {
+            Jws<Claims> result = parser.parseClaimsJws(token);
+            log.info("Jws result : {}", result.getBody());
+            return new HashMap<String, Object>(result.getBody());
+
+        } catch (Exception e) {
+
+            if (e instanceof SignatureException) {
+                throw new JwtException(TokenErrorCode.INVALID_TOKEN, e);
+            }
+            else if (e instanceof ExpiredJwtException) {
+                throw new JwtException(TokenErrorCode.EXPIRED_TOKEN, e);
+            }
+            else if (e instanceof MalformedJwtException) {
+                throw new JwtException(TokenErrorCode.INVALID_TOKEN, e);
+            }
+            else {
+                throw new JwtException(TokenErrorCode.TOKEN_EXCEPTION, e);
+            }
+        }
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/domain/token/model/TokenDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/token/model/TokenDto.java
@@ -1,0 +1,18 @@
+package trendravel.photoravel_be.domain.token.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenDto {
+
+    private String token;
+    private LocalDateTime expiredAt;
+}

--- a/src/main/java/trendravel/photoravel_be/domain/token/model/TokenResponse.java
+++ b/src/main/java/trendravel/photoravel_be/domain/token/model/TokenResponse.java
@@ -1,0 +1,16 @@
+package trendravel.photoravel_be.domain.token.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.antlr.v4.runtime.Token;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenResponse {
+    private TokenDto accessToken;
+    private TokenDto refreshToken;
+}

--- a/src/main/java/trendravel/photoravel_be/domain/token/service/TokenService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/token/service/TokenService.java
@@ -1,0 +1,98 @@
+package trendravel.photoravel_be.domain.token.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import trendravel.photoravel_be.commom.error.ErrorCode;
+import trendravel.photoravel_be.commom.error.MemberErrorCode;
+import trendravel.photoravel_be.commom.exception.ApiException;
+import trendravel.photoravel_be.db.member.MemberEntity;
+import trendravel.photoravel_be.db.respository.member.MemberRepository;
+import trendravel.photoravel_be.domain.token.helper.TokenHelper;
+import trendravel.photoravel_be.db.inmemorydb.entity.Token;
+import trendravel.photoravel_be.domain.token.model.TokenDto;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TokenService {
+
+    private final TokenHelper tokenHelper;
+    private final MemberRepository memberRepository;
+    private final RedisTemplate<String, Token> redisTemplate;
+
+    public TokenDto issueAccessToken(String email) {
+        MemberEntity member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new ApiException(MemberErrorCode.USER_NOT_FOUND));
+
+        HashMap<String, Object> data = new HashMap<>();
+        data.put("email", member.getEmail());
+        data.put("name", member.getName());
+        data.put("nickname", member.getNickname());
+        data.put("memberId", member.getMemberId());
+        return tokenHelper.issueAccessToken(data);
+    }
+
+    public TokenDto issueAccessTokenForMemberId(String memberId) {
+        MemberEntity member = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new ApiException(MemberErrorCode.USER_NOT_FOUND));
+
+        HashMap<String, Object> data = new HashMap<>();
+        data.put("email", member.getEmail());
+        data.put("name", member.getName());
+        data.put("nickname", member.getNickname());
+        data.put("memberId", member.getMemberId());
+        return tokenHelper.issueAccessToken(data);
+    }
+
+    public TokenDto issueRefreshToken(String email) {
+        MemberEntity member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new ApiException(MemberErrorCode.USER_NOT_FOUND));
+        HashMap<String, Object> data = new HashMap<>();
+        data.put("email", member.getEmail());
+        data.put("name", member.getName());
+        data.put("nickname", member.getNickname());
+        data.put("memberId", member.getMemberId());
+
+        TokenDto refreshToken = tokenHelper.issueRefreshToken(data);
+        saveRefreshToken(refreshToken, member.getMemberId());
+
+        return refreshToken;
+    }
+
+    public String validationTokenWithEmail(String token){
+
+        Map<String, Object> data = tokenHelper.validationTokenWithThrow(token);
+        Object userEmail = data.get("email");
+        Objects.requireNonNull(userEmail, () -> {
+            throw new ApiException(ErrorCode.NULL_POINT);
+        });
+        return userEmail.toString();
+    }
+
+    public String validationTokenWithMemberId(String token){
+
+        Map<String, Object> data = tokenHelper.validationTokenWithThrow(token);
+        Object memberId = data.get("memberId");
+        Objects.requireNonNull(memberId, () -> {
+            throw new ApiException(ErrorCode.NULL_POINT);
+        });
+        return memberId.toString();
+    }
+
+    public Token saveRefreshToken(TokenDto tokendto, String memberId) {
+        Token token = Token.builder()
+                .id(memberId)
+                .refreshToken(tokendto.getToken())
+                .build();
+
+        redisTemplate.opsForHash().put("refresh_token", token.getId(), token);
+        return token;
+    }
+
+}

--- a/src/main/java/trendravel/photoravel_be/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/trendravel/photoravel_be/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,89 @@
+package trendravel.photoravel_be.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import trendravel.photoravel_be.commom.error.TokenErrorCode;
+import trendravel.photoravel_be.commom.exception.JwtException;
+import trendravel.photoravel_be.db.inmemorydb.entity.Token;
+import trendravel.photoravel_be.domain.authentication.session.UserSession;
+import trendravel.photoravel_be.domain.token.service.TokenService;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final UserDetailsService userDetailsService;
+    private final TokenService tokenService;
+    private final RedisTemplate<String, Token> redisTemplate;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // 요청 URI를 가져옴
+        String path = request.getRequestURI();
+
+        // 인증이 필요한지 체크
+        if (!isAuthenticationRequired(path)) {
+            // 인증이 필요 없는 경우, 필터를 통과.
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = getToken(request);
+
+        if(StringUtils.hasText(token)){
+            String memberId = tokenService.validationTokenWithMemberId(token);
+            Token storedRefreshToken = (Token) redisTemplate.opsForHash().get("refresh_token", memberId);
+
+            if (storedRefreshToken != null) {
+                String storedMemberId = tokenService.validationTokenWithMemberId(storedRefreshToken.getRefreshToken());
+                if (memberId.equals(storedMemberId)) {
+                    UserSession userSession = (UserSession) userDetailsService.loadUserByUsername(memberId);
+                    log.info("user session : {}", userSession.getUsername());
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userSession, null, userSession.getAuthorities());
+                    // 인증 정보 생성
+                    usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    //인증 정보를 SecurityContextHolder 에 저장
+                    SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+                    filterChain.doFilter(request, response);
+                } else {
+                    throw new JwtException(TokenErrorCode.INVALID_TOKEN);
+                }
+            } else {
+                throw new JwtException(TokenErrorCode.REFRESH_TOKEN_NOT_VALID);
+            }
+        }else {
+            throw new JwtException(TokenErrorCode.AUTHORIZATION_TOKEN_NOT_FOUND);
+        }
+    }
+
+
+    private String getToken(HttpServletRequest req){
+        String token = req.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return null;
+    }
+
+    private boolean isAuthenticationRequired(String path) {
+        // 인증이 필요 없는 경로를 정의
+        return !(path.startsWith("/public") || path.startsWith("/login") || path.startsWith("/swagger-ui") || path.startsWith("/v3/api-docs"));
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/filter/JwtExceptionFilter.java
+++ b/src/main/java/trendravel/photoravel_be/filter/JwtExceptionFilter.java
@@ -1,0 +1,68 @@
+package trendravel.photoravel_be.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.filter.OncePerRequestFilter;
+import trendravel.photoravel_be.commom.error.ErrorCodeIfs;
+import trendravel.photoravel_be.commom.error.MemberErrorCode;
+import trendravel.photoravel_be.commom.error.TokenErrorCode;
+import trendravel.photoravel_be.commom.exception.JwtException;
+import trendravel.photoravel_be.commom.response.Api;
+
+import java.io.IOException;
+
+/**
+ * 인증 필터에서 발생하는 JwtException을 잡는 필터입니다.
+ * 스프링 필터체인에서 발생하는 에러는 exception 핸들러에서 잡아내지 못하므로(스프링 컨텍스트 밖이기 때문..?)
+ * 따로 필터를 만들어서 예외를 처리합니다.
+ * 이 필터에서 filterChain.doFilter 를 진행하다가 예외가 터지는걸 잡습니다.
+ */
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        log.info("JwtExceptionFilter request : {}" , request.getRequestURI());
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (UsernameNotFoundException e) {
+            response(response, MemberErrorCode.USER_NOT_FOUND);
+        }
+        catch (JwtException e) {
+            if (e.getErrorCodeIfs().getHttpStatusCode() == 2000) {
+                response(response, TokenErrorCode.INVALID_TOKEN);
+            } else if (e.getErrorCodeIfs().getHttpStatusCode() == 2001) {
+                response(response, TokenErrorCode.EXPIRED_TOKEN);
+            }else if (e.getErrorCodeIfs().getHttpStatusCode() == 2003) {
+                response(response, TokenErrorCode.AUTHORIZATION_TOKEN_NOT_FOUND);
+            } else if (e.getErrorCodeIfs().getHttpStatusCode() == 2004) {
+                response(response, TokenErrorCode.REFRESH_TOKEN_NOT_VALID);
+            } else {
+                response(response, TokenErrorCode.TOKEN_EXCEPTION);
+            }
+        }
+    }
+
+    private void response(HttpServletResponse response, ErrorCodeIfs errorCodeIfs) throws IOException {
+        Api apiResponse = Api.ERROR(errorCodeIfs);
+        String responseBody = objectMapper.writeValueAsString(apiResponse);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(apiResponse.getResult().getResultCode());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}


### PR DESCRIPTION
## Feat
- 멤버 crud 기능 구현
- 멤버 local login 기능 구현
- jwt 토큰 발행 및 검증 로직 구현

## Test
- 멤버 create
<img width="710" alt="스크린샷 2024-09-01 오후 7 13 56" src="https://github.com/user-attachments/assets/5e26668c-4c11-4186-bbd4-298ae5ce0b91">

- 멤버 update
request
<img width="419" alt="member update request" src="https://github.com/user-attachments/assets/4c93c96e-1508-4069-8803-3052216359ea">

response
<img width="706" alt="member update response" src="https://github.com/user-attachments/assets/0638da7a-5f31-4815-b200-7f54ac341bb0">

- 멤버 read
request
<img width="550" alt="member read request" src="https://github.com/user-attachments/assets/2479f385-c720-41f3-b056-a64139b2ac11">

response
<img width="708" alt="member read response" src="https://github.com/user-attachments/assets/fc4a16dc-3d2d-45d5-8c84-db595169b9f7">

- 멤버 delete
request
<img width="545" alt="member delete request" src="https://github.com/user-attachments/assets/61b89c41-bfd2-4356-ab62-f602a233e434">

response
<img width="378" alt="member delete response" src="https://github.com/user-attachments/assets/fe6929c0-61f1-4fac-a07d-d1e1e4370d4b">

- local login
request
<img width="384" alt="member local login request" src="https://github.com/user-attachments/assets/fe6d9b22-ab33-43a8-bf8b-b5d7d1b6a187">

response
<img width="734" alt="member local login response" src="https://github.com/user-attachments/assets/c8967aa9-e169-4db9-ab13-09b9c6002d47">

- private controller는 Authorization header에 access token 추가 후 요청
<img width="578" alt="header에 token 추가" src="https://github.com/user-attachments/assets/9e7f178c-d6f1-4088-8ce1-28fc8f5cd237">

- email, nickname, memberId 중복 테스트
reqeust
<img width="544" alt="중복 테스트" src="https://github.com/user-attachments/assets/1b1b4e99-f1c1-4cb8-a544-87a3fae5134d">

response
1. 중복되었을 경우 true
<img width="387" alt="중복 테스트 응답" src="https://github.com/user-attachments/assets/3747c041-af72-418b-8fbf-77d328615e9e">

2. 중복되지 않았을 경우 false
<img width="347" alt="중복 테스트(중복이 없을 경우)" src="https://github.com/user-attachments/assets/0c941328-66cd-4881-b9c2-71dcb1cd4939">

- JWT token 오류 응답 메세지
invalid
<img width="416" alt="invalid" src="https://github.com/user-attachments/assets/e0143ed4-dde1-48d1-9fc6-f90b59e17fd8">

expired
<img width="440" alt="expired" src="https://github.com/user-attachments/assets/b230e260-e14a-4989-8514-dff9a7194aea">

token header not found
<img width="400" alt="token header not found" src="https://github.com/user-attachments/assets/3f9e6d6b-246a-43f7-bda6-10edb2241b11">

redis에 저장된 refresh token이 없을 경우(이전에 로그인 했다가 로그아웃했을 경우, 다시 로그인이 필요한 경우)
<img width="559" alt="redis에 refresh token이 없을 경우(로그인이 필요한 경우)" src="https://github.com/user-attachments/assets/9b6d24d4-1d86-4c90-bab2-f033e75c0c17">

(error code 2002는 알 수 없는 토큰 에러로, 예기치 못한 예외 상황입니다.)


## Docs

- build.gradle 파일 변경 사항

// redis
implementation 'org.springframework.boot:spring-boot-starter-data-redis'
implementation 'io.lettuce:lettuce-core'
 // oauth2-client
implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
// spring security
implementation 'org.springframework.boot:spring-boot-starter-security'
// jwt token
implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
