### PR TITLE
[!HOTFIX/Feat] S3 Rollback 문제 해결을 위한 ImageServiceEvent 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,9 @@ dependencies {
 	implementation 'org.locationtech.jts:jts-core:1.18.2'
 	implementation 'mysql:mysql-connector-java:8.0.32'
 	implementation 'io.minio:minio:8.5.11'
-	implementation 'io.findify:s3mock_2.13:0.2.6'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation(platform("software.amazon.awssdk:bom:2.21.1"))
+	implementation("software.amazon.awssdk:s3")
 
 	//Querydsl 추가
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/trendravel/photoravel_be/commom/event/ImageDeleteEvent.java
+++ b/src/main/java/trendravel/photoravel_be/commom/event/ImageDeleteEvent.java
@@ -1,0 +1,14 @@
+package trendravel.photoravel_be.commom.event;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ImageDeleteEvent {
+    private List<String> deleteImages = new ArrayList<>();
+}

--- a/src/main/java/trendravel/photoravel_be/commom/event/ImageUploadEvent.java
+++ b/src/main/java/trendravel/photoravel_be/commom/event/ImageUploadEvent.java
@@ -1,0 +1,15 @@
+package trendravel.photoravel_be.commom.event;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ImageUploadEvent {
+    private List<MultipartFile> uploadImages = new ArrayList<>();
+}

--- a/src/main/java/trendravel/photoravel_be/commom/eventHandler/ImageServiceEventHandler.java
+++ b/src/main/java/trendravel/photoravel_be/commom/eventHandler/ImageServiceEventHandler.java
@@ -1,0 +1,36 @@
+package trendravel.photoravel_be.commom.eventHandler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import trendravel.photoravel_be.commom.event.ImageUploadEvent;
+import trendravel.photoravel_be.commom.event.ImageDeleteEvent;
+import trendravel.photoravel_be.commom.image.service.ImageService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ImageServiceEventHandler {
+
+    private final ImageService imageService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleImageUploadExceptionEventListener(ImageUploadEvent imageUploadEvent){
+        log.info("DB 저장 성공, S3 저장 이미지 저장");
+        imageService.uploadImages(imageUploadEvent.getUploadImages());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleImageDeleteExceptionEventListener(ImageDeleteEvent imageDeleteEvent){
+        log.info("DB 저장 성공, S3 이미지 삭제");
+        imageService.deleteAllImages(imageDeleteEvent.getDeleteImages());
+    }
+
+
+}

--- a/src/main/java/trendravel/photoravel_be/commom/exceptionhandler/GlobalExHandler.java
+++ b/src/main/java/trendravel/photoravel_be/commom/exceptionhandler/GlobalExHandler.java
@@ -57,8 +57,8 @@ public class GlobalExHandler {
                 .collect(Collectors.toCollection(ArrayList::new));
 
         return ResponseEntity
-                .status(500)
-                .body(Api.ERROR(500,
+                .status(400)
+                .body(Api.ERROR(400,
                         errors.stream().toList().toString()));
     }
 

--- a/src/main/java/trendravel/photoravel_be/commom/image/service/ImageService.java
+++ b/src/main/java/trendravel/photoravel_be/commom/image/service/ImageService.java
@@ -1,14 +1,18 @@
 package trendravel.photoravel_be.commom.image.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 import trendravel.photoravel_be.commom.error.ErrorCode;
+import trendravel.photoravel_be.commom.event.ImageUploadEvent;
+import trendravel.photoravel_be.commom.event.ImageDeleteEvent;
 import trendravel.photoravel_be.commom.exception.ImageSystemException;
 import trendravel.photoravel_be.commom.image.util.ImageNameRebuildUtils;
 
@@ -26,18 +30,40 @@ public class ImageService {
     private final S3Client amazonS3;
     private final S3Client minioClient;
 
+    private final ApplicationEventPublisher eventPublisher;
+
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
 
+    @Transactional
+    public List<String> uploadImageFacade(List<MultipartFile> imageFiles) {
+        eventPublisher.publishEvent(new ImageUploadEvent(imageFiles));
+        return getImagesName(imageFiles);
+    }
 
-    public List<String> uploadImages(List<MultipartFile> images){
-
-        if(images == null){
-            return null;
+    @Transactional
+    public List<String> updateImageFacade(List<MultipartFile> newImages,
+                                          List<String> deleteImages){
+        eventPublisher.publishEvent(new ImageDeleteEvent(deleteImages));
+        eventPublisher.publishEvent(new ImageUploadEvent(newImages));
+        if(newImages == null || newImages.isEmpty()){
+            return new ArrayList<>();
         }
 
-//        return uploadImagesAndReturnUrl(images, amazonS3);
-        return uploadImagesAndReturnUrl(images, minioClient);
+        return getImagesName(newImages);
+    }
+
+    @Transactional
+    public void deleteAllImagesFacade(List<String> deleteImages){
+        eventPublisher.publishEvent(new ImageDeleteEvent(deleteImages));
+    }
+
+    public void uploadImages(List<MultipartFile> images){
+        if(images == null){
+            return;
+        }
+        uploadImagesAndReturnUrl(images, minioClient);
+//      uploadImagesAndReturnUrl(images, amazonS3);
     }
 
 
@@ -61,33 +87,28 @@ public class ImageService {
         return rebuildImageName;
     }
 
-    public List<String> updateImages(List<MultipartFile> newImages,
-                                     List<String> deleteImages){
-
-        deleteAllImages(deleteImages);
-
-        if(newImages == null){
-            return new ArrayList<>();
-        }
 
 
-//        return uploadImagesAndReturnUrl(newImages, amazonS3);
-        return uploadImagesAndReturnUrl(newImages, minioClient);
-    }
-
+    /**
+     * db에 들어있는 경우만 지우기!
+     */
 
     public void deleteAllImages(List<String> deleteImages){
+        deleteImagesInStorage(deleteImages, minioClient);
+//        deleteImagesInStorage(deleteImages, amazonS3);
+    }
+
+    private void deleteImagesInStorage(List<String> deleteImages, S3Client storage) {
         List<String> imageNames = sliceUrlAndGetImageNames(deleteImages);
         log.info("{}", imageNames.get(0));
         for (String imageName : imageNames) {
-//            amazonS3.deleteObject(bucketName, imageName);
             log.info("{}", imageName);
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest
                     .builder()
                     .bucket(bucketName)
                     .key(imageName)
                     .build();
-            minioClient.deleteObject(deleteObjectRequest);
+            storage.deleteObject(deleteObjectRequest);
         }
     }
 
@@ -98,7 +119,7 @@ public class ImageService {
     }
 
 
-    public List<String> getImagesName(List<MultipartFile> multipartFiles){
+    private List<String> getImagesName(List<MultipartFile> multipartFiles){
         return multipartFiles.stream()
                 .map(p-> ImageNameRebuildUtils
                         .buildImageName(p.getOriginalFilename()))

--- a/src/main/java/trendravel/photoravel_be/config/S3Config.java
+++ b/src/main/java/trendravel/photoravel_be/config/S3Config.java
@@ -1,15 +1,14 @@
 package trendravel.photoravel_be.config;
 
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.*;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.net.URI;
 
 @Configuration
 public class S3Config {
@@ -34,21 +33,26 @@ public class S3Config {
 
 
     @Bean
-    public AmazonS3 amazonS3(){
-        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, accessSecret);
-        return AmazonS3ClientBuilder
-                .standard()
-                .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+    public S3Client amazonS3(){
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider
+                        .create(AwsBasicCredentials
+                                .create(accessKey, accessSecret)))
                 .build();
     }
 
+
+
     @Bean
-    public AmazonS3 minioClient(){
-        return AmazonS3ClientBuilder.standard()
-                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(minioUrl, region))
-                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(minioAccessKey, minioSecretKey)))
-                .withPathStyleAccessEnabled(true)
+    public S3Client minioClient(){
+        return S3Client.builder()
+                .endpointOverride(URI.create(minioUrl))
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider
+                        .create(AwsBasicCredentials
+                                .create(minioAccessKey, minioSecretKey)))
+                .forcePathStyle(true)
                 .build();
     }
 

--- a/src/main/java/trendravel/photoravel_be/db/location/Location.java
+++ b/src/main/java/trendravel/photoravel_be/db/location/Location.java
@@ -62,6 +62,7 @@ public class Location extends BaseEntity {
             joinColumns = @JoinColumn(name = "location_id")
     )
     @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
+    @Builder.Default
     private List<String> images = new ArrayList<>();
     private int views;
 
@@ -76,6 +77,11 @@ public class Location extends BaseEntity {
     @Builder.Default
     private List<Review> review = new ArrayList<>();
 
+    public void createLocationImage(List<String> imageNames){
+        images.addAll(imageNames);
+    }
+
+
     public void updateLocation(LocationUpdateImagesDto location, List<String> newImages){
         this.longitude = location.getLongitude();
         this.latitude = location.getLatitude();
@@ -85,9 +91,7 @@ public class Location extends BaseEntity {
         this.point = new GeometryFactory()
                 .createPoint(new Coordinate(latitude, longitude));
         this.point.setSRID(4326);
-        for (String deleteImage : location.getDeleteImages()) {
-            this.images.remove(deleteImage);
-        }
+        this.images.removeAll(location.getDeleteImages());
         this.images.addAll(newImages);
     }
 

--- a/src/main/java/trendravel/photoravel_be/db/review/Review.java
+++ b/src/main/java/trendravel/photoravel_be/db/review/Review.java
@@ -12,6 +12,7 @@ import trendravel.photoravel_be.domain.review.dto.request.ReviewRequestDto;
 import trendravel.photoravel_be.db.review.enums.ReviewTypes;
 import trendravel.photoravel_be.domain.review.dto.request.ReviewUpdateImagesDto;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -45,8 +46,8 @@ public class Review extends BaseEntity {
             name = "review_images",
             joinColumns = @JoinColumn(name = "review_id")
     )
-    @Size(max = 10)
-    private List<String> images;
+    @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
+    private List<String> images = new ArrayList<>();
 
     // 회원, 가이드 관련 연관관계 필드 추가 필요
 

--- a/src/main/java/trendravel/photoravel_be/db/review/Review.java
+++ b/src/main/java/trendravel/photoravel_be/db/review/Review.java
@@ -47,6 +47,7 @@ public class Review extends BaseEntity {
             joinColumns = @JoinColumn(name = "review_id")
     )
     @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
+    @Builder.Default
     private List<String> images = new ArrayList<>();
 
     // 회원, 가이드 관련 연관관계 필드 추가 필요
@@ -59,6 +60,12 @@ public class Review extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "spot_id")
     private Spot spotReview;
+
+
+    public void createReviewImage(List<String> imageNames){
+        images.addAll(imageNames);
+    }
+
 
     //연관관계 편의 메소드
     public void setSpotReview(Spot spot) {

--- a/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
+++ b/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.hibernate.validator.constraints.Length;
 import trendravel.photoravel_be.db.BaseEntity;
 import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.domain.spot.dto.request.SpotRequestDto;
@@ -28,7 +29,9 @@ public class Spot extends BaseEntity {
     @Column(name = "spot_id")
     private Long id;
 
+    @Column(length = 50)
     @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 50, message="최대 길이는 50자 입니다.")
     private String title;
 
     @Column(columnDefinition = "TEXT")
@@ -47,7 +50,7 @@ public class Spot extends BaseEntity {
             joinColumns = @JoinColumn(name = "spot_id")
     )
     @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
-    private List<String> images;
+    private List<String> images = new ArrayList<>();
 
 
 

--- a/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
+++ b/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
@@ -50,8 +50,8 @@ public class Spot extends BaseEntity {
             joinColumns = @JoinColumn(name = "spot_id")
     )
     @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
+    @Builder.Default
     private List<String> images = new ArrayList<>();
-
 
 
     //유저 엔티티 생성 후, 연관관계 필드 추가 필요
@@ -64,6 +64,10 @@ public class Spot extends BaseEntity {
     @OneToMany(mappedBy = "spotReview", orphanRemoval = true)
     @Builder.Default
     private List<Review> reviews = new ArrayList<>();
+
+    public void createSpotImage(List<String> imageNames){
+        images.addAll(imageNames);
+    }
 
     //연관관계 편의 메소드
     public void setLocation(Location location){

--- a/src/main/java/trendravel/photoravel_be/domain/guide/service/GuideService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/guide/service/GuideService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.error.ErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
-import trendravel.photoravel_be.commom.service.ImageService;
+import trendravel.photoravel_be.commom.image.service.ImageService;
 import trendravel.photoravel_be.db.guide.Guide;
 import trendravel.photoravel_be.db.respository.guide.GuideRepository;
 import trendravel.photoravel_be.db.review.Review;
@@ -101,8 +101,12 @@ public class GuideService {
         }
         
         Guide guide = guideOpt.get();
-        guide.updateGuide(guideRequestDto, imageService.uploadImages(images));
-        
+
+        /**
+         * 삭제할 이미지 리스트 필요, 에러 발생으로 주석처리. 수정 필요
+         */
+//        guide.updateGuide(guideRequestDto, imageService.updateImageFacade(images));
+        imageService.uploadImages(images);
         //List<RecentReviewsDto> reviews = guideRepository.recentReviews(guide.getId());
         
         return GuideResponseDto.builder()

--- a/src/main/java/trendravel/photoravel_be/domain/guidebook/service/GuidebookService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/guidebook/service/GuidebookService.java
@@ -4,12 +4,12 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import trendravel.photoravel_be.commom.image.service.ImageService;
 import trendravel.photoravel_be.domain.guidebook.dto.request.GuidebookRequestDto;
 import trendravel.photoravel_be.domain.guidebook.dto.response.GuidebookResponseDto;
 import trendravel.photoravel_be.db.guidebook.Guidebook;
 import trendravel.photoravel_be.db.enums.Region;
 import trendravel.photoravel_be.db.respository.guidebook.GuidebookRepository;
-import trendravel.photoravel_be.commom.service.ImageService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,11 +33,11 @@ public class GuidebookService {
                 .title(guidebookRequestDto.getTitle())
                 .content(guidebookRequestDto.getContent())
                 .region(guidebookRequestDto.getRegion())
-                .images(imageService.uploadImages(images))
+                .images(imageService.uploadImageFacade(images))
                 .views(0)
                 .build());
-        
-        
+
+        imageService.uploadImages(images);
         return GuidebookResponseDto.builder()
                 .id(guidebook.getId())
                 .userId(guidebook.getUserId())
@@ -137,8 +137,12 @@ public class GuidebookService {
         }
         
         Guidebook guidebook = guidebookOpt.get();
-        guidebook.updateGuidebook(guidebookRequestDto, imageService.uploadImages(images));
-        
+
+        /**
+         * 삭제 이미지 리스트 필요, 수정 필요.
+         */
+//        guidebook.updateGuidebook(guidebookRequestDto, imageService.updateImageFacade(images));
+        imageService.uploadImages(images);
         return GuidebookResponseDto.builder()
                 .id(guidebook.getId())
                 .userId(guidebook.getUserId())

--- a/src/main/java/trendravel/photoravel_be/domain/location/controller/LocationController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/controller/LocationController.java
@@ -29,7 +29,7 @@ public class LocationController {
 
     @Schema(description = "장소 CREATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PostMapping(value = "/location/create")
+    @PostMapping(value = "/private/location/create")
     public Api<LocationResponseDto> locationCreate(@RequestBody
                                            LocationRequestDto locationRequestDto) {
 
@@ -38,7 +38,7 @@ public class LocationController {
 
     @Schema(description = "장소 CREATE 요청/응답 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PostMapping(value = "/location/create",
+    @PostMapping(value = "/private/location/create",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<LocationResponseDto> locationCreate(@RequestPart(value = "data")
@@ -90,7 +90,7 @@ public class LocationController {
 
     @Schema(description = "장소 UPDATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PatchMapping(value = "/location/update")
+    @PatchMapping(value = "/private/location/update")
     public Api<LocationResponseDto> locationUpdate(@RequestBody
                                                        LocationRequestDto locationRequestDto) {
 
@@ -100,7 +100,7 @@ public class LocationController {
 
     @Schema(description = "장소 UPDATE 요청/응답 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PatchMapping(value = "/location/update",
+    @PatchMapping(value = "/private/location/update",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<LocationResponseDto> locationUpdate(@RequestPart(value = "data")
@@ -114,7 +114,7 @@ public class LocationController {
 
 
     @Schema(description = "장소 DELETE 요청/응답")
-    @DeleteMapping("/location/{locationId}/delete")
+    @DeleteMapping("/private/location/{locationId}/delete")
     public Result locationDelete(@PathVariable("locationId") Long locationId) {
         locationService.deleteLocation(locationId);
 

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationMultiReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationMultiReadResponseDto.java
@@ -34,7 +34,9 @@ public class LocationMultiReadResponseDto {
     @Schema(description = "장소별 조회수")
     private int views;
     @Schema(description = "장소 리뷰 평균 평점")
-    private String ratingAvg;
+    private Double ratingAvg;
+    @Schema(description = "장소 리뷰 수")
+    private Integer reviewCounts;
 
     //유저 객체 추가 필요
 

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationMultiReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationMultiReadResponseDto.java
@@ -40,8 +40,6 @@ public class LocationMultiReadResponseDto {
 
     //유저 객체 추가 필요
 
-    // 프론트엔드측과 의논 후 추가 여부 결정
-    // private List<RecentReviewsDto> recentReviewDtos;
 
     @Schema(description = "장소 생성일")
     private LocalDateTime createAt;

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationSingleReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationSingleReadResponseDto.java
@@ -33,7 +33,9 @@ public class LocationSingleReadResponseDto {
     @Schema(description = "장소 조회수")
     private int views;
     @Schema(description = "장소 리뷰 평균 평점")
-    private String ratingAvg;
+    private Double ratingAvg;
+    @Schema(description = "장소 리뷰 수")
+    private Integer reviewCounts;
 
     //유저 객체 추가 필요
     @Schema(description = "최근 업데이트된 리뷰 목록 (최대 3개)")

--- a/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
@@ -1,11 +1,12 @@
 package trendravel.photoravel_be.domain.location.service;
 
 
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.error.LocationErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
@@ -98,7 +99,7 @@ public class LocationService {
                 .build();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public LocationSingleReadResponseDto readSingleLocation(Long id){
         Location location = locationRepository.findById(id)
                 .orElseThrow(() -> new ApiException(LocationErrorCode.LOCATION_NOT_FOUND));
@@ -123,7 +124,7 @@ public class LocationService {
                 .build();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<LocationMultiReadResponseDto> readMultiLocation(
             LocationNowPositionDto locationNowPositionDto){
         List<Location> locations =
@@ -140,7 +141,7 @@ public class LocationService {
                 .toList();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<LocationMultiReadResponseDto> readMultiLocation(
             LocationKeywordDto locationKeywordDto){
         List<Location> locations = locationRepository.searchKeyword(locationKeywordDto);

--- a/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
@@ -1,5 +1,6 @@
 package trendravel.photoravel_be.domain.location.service;
 
+
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.locationtech.jts.geom.Coordinate;
@@ -45,7 +46,6 @@ public class LocationService {
                 .latitude(locationRequestDto.getLatitude())
                 .longitude(locationRequestDto.getLongitude())
                 .address(locationRequestDto.getAddress())
-                .images(imageService.uploadImages(images))
                 .views(0)
                 .point(new GeometryFactory().createPoint(
                                 new Coordinate(locationRequestDto.getLatitude()
@@ -53,6 +53,8 @@ public class LocationService {
                 .build();
         location.getPoint().setSRID(4326);
         locationRepository.save(location);
+        location.createLocationImage(imageService.uploadImages(images));
+
 
         return LocationResponseDto
                 .builder()

--- a/src/main/java/trendravel/photoravel_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/controller/ReviewController.java
@@ -25,7 +25,7 @@ public class ReviewController {
 
     @Schema(description = "리뷰 CREATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PostMapping(value = "/review/create")
+    @PostMapping(value = "/private/review/create")
     public Api<ReviewResponseDto> createReview(@RequestBody
                                                    ReviewRequestDto reviewRequestDto){
 
@@ -34,7 +34,7 @@ public class ReviewController {
 
     @Schema(description = "리뷰 CREATE 요청/응답 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PostMapping(value = "/review/create",
+    @PostMapping(value = "/private/review/create",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<ReviewResponseDto> createReview(@RequestPart(value = "data")
@@ -64,7 +64,7 @@ public class ReviewController {
 
     @Schema(description = "리뷰 UPDATE 요청 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PatchMapping(value = "/review/update")
+    @PatchMapping(value = "/private/review/update")
     public Api<ReviewResponseDto> updateReview(@RequestBody
                                                ReviewRequestDto reviewRequestDto){
 
@@ -73,7 +73,7 @@ public class ReviewController {
 
     @Schema(description = "리뷰 UPDATE 요청 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PatchMapping(value = "/review/update",
+    @PatchMapping(value = "/private/review/update",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<ReviewResponseDto> updateReview(@RequestPart(value = "data")
@@ -85,7 +85,7 @@ public class ReviewController {
     }
 
     @Schema(description = "리뷰 DELETE 요청")
-    @DeleteMapping(value ="/review/{reviewId}/delete")
+    @DeleteMapping(value ="/private/review/{reviewId}/delete")
     public Result locationDelete(@PathVariable("reviewId") Long reviewId) {
         reviewService.deleteReview(reviewId);
 

--- a/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
@@ -52,9 +52,8 @@ public class ReviewService {
                     .orElseThrow(() -> new ApiException(SpotErrorCode.SPOT_NOT_FOUND));
         }
 
-        Review review = reviewRepository.save(Review.builder()
+        Review review = Review.builder()
                 .reviewType(reviewRequestDto.getReviewType())
-                .images(imageService.uploadImages(images))
                 .content(reviewRequestDto.getContent())
                 .rating(reviewRequestDto.getRating())
                 .locationReview(ReviewTypes.LOCATION ==
@@ -63,10 +62,12 @@ public class ReviewService {
                 .spotReview(ReviewTypes.SPOT ==
                         reviewRequestDto.getReviewType()
                         ? spot : null)
-                .build());
+                .build();
 
         review.setLocationReview(location);
         review.setSpotReview(spot);
+        reviewRepository.save(review);
+        review.createReviewImage(imageService.uploadImages(images));
 
         return ReviewResponseDto
                 .builder()
@@ -98,7 +99,7 @@ public class ReviewService {
         }
 
 
-        Review review = reviewRepository.save(Review.builder()
+        Review review = Review.builder()
                 .reviewType(reviewRequestDto.getReviewType())
                 .content(reviewRequestDto.getContent())
                 .rating(reviewRequestDto.getRating())
@@ -108,7 +109,7 @@ public class ReviewService {
                 .spotReview(ReviewTypes.SPOT ==
                         reviewRequestDto.getReviewType()
                         ? spot : null)
-                .build());
+                .build();
 
 
         /**
@@ -120,7 +121,7 @@ public class ReviewService {
             review.setLocationReview(location);
         }
 
-
+        reviewRepository.save(review);
 
 
         return ReviewResponseDto

--- a/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
@@ -1,10 +1,10 @@
 package trendravel.photoravel_be.domain.review.service;
 
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import trendravel.photoravel_be.commom.error.ErrorCode;
 import trendravel.photoravel_be.commom.error.LocationErrorCode;
 import trendravel.photoravel_be.commom.error.ReviewErrorCode;
 import trendravel.photoravel_be.commom.error.SpotErrorCode;
@@ -32,6 +32,7 @@ public class ReviewService {
     private final LocationRepository locationRepository;
     private final ImageService imageService;
 
+    @Transactional
     public ReviewResponseDto createReview(
             ReviewRequestDto reviewRequestDto, List<MultipartFile> images) {
 
@@ -79,6 +80,7 @@ public class ReviewService {
                 .build();
     }
 
+    @Transactional
     public ReviewResponseDto createReview(
             ReviewRequestDto reviewRequestDto) {
 
@@ -132,7 +134,7 @@ public class ReviewService {
                 .build();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ReviewResponseDto> readAllLocationReview(Long locationId){
         List<Review> reviews = locationRepository.findById(locationId)
                 .map(Location::getReview)
@@ -145,7 +147,7 @@ public class ReviewService {
                 .toList();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ReviewResponseDto> readAllSpotReview(Long locationId, Long spotId){
         List<Spot> spots = locationRepository.findById(locationId)
                 .map(Location::getSpot)

--- a/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
@@ -62,13 +62,14 @@ public class ReviewService {
                 .spotReview(ReviewTypes.SPOT ==
                         reviewRequestDto.getReviewType()
                         ? spot : null)
+                .images(imageService.uploadImageFacade(images))
                 .build();
 
         review.setLocationReview(location);
         review.setSpotReview(spot);
         reviewRepository.save(review);
-        review.createReviewImage(imageService.uploadImages(images));
 
+        imageService.uploadImages(images);
         return ReviewResponseDto
                 .builder()
                 .ReviewId(review.getId())
@@ -176,7 +177,7 @@ public class ReviewService {
                 reviewRequestDto.getReviewId())
                 .orElseThrow(() -> new ApiException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
-        review.updateReview(reviewRequestDto, imageService.updateImages(images,
+        review.updateReview(reviewRequestDto, imageService.updateImageFacade(images,
                 reviewRequestDto.getDeleteImages()));
 
         return ReviewResponseDto
@@ -218,7 +219,7 @@ public class ReviewService {
         Review findReview = reviewRepository.findById(id)
                 .orElseThrow(() -> new ApiException(ReviewErrorCode.REVIEW_NOT_FOUND));
         reviewRepository.deleteById(findReview.getId());
-        imageService.deleteAllImages(findReview.getImages());
+        imageService.deleteAllImagesFacade(findReview.getImages());
     }
 
 }

--- a/src/main/java/trendravel/photoravel_be/domain/spot/controller/SpotController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/controller/SpotController.java
@@ -28,7 +28,7 @@ public class SpotController {
 
     @Schema(description = "스팟 CREATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PostMapping(value = "/spot/create")
+    @PostMapping(value = "/private/spot/create")
     public Api<SpotResponseDto> spotCreate(@RequestBody
                                        SpotRequestDto spotRequestDto){
 
@@ -37,7 +37,7 @@ public class SpotController {
 
     @Schema(description = "스팟 CREATE 요청/응답 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PostMapping(value = "/spot/create",
+    @PostMapping(value = "/private/spot/create",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<SpotResponseDto> spotCreate(@RequestPart(value = "data")
@@ -67,7 +67,7 @@ public class SpotController {
 
     @Schema(description = "스팟 UPDATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PatchMapping(value = "/spot/update")
+    @PatchMapping(value = "/private/spot/update")
     public Api<SpotResponseDto> spotUpdate(@RequestBody
                                        SpotRequestDto spotRequestDto) {
 
@@ -76,7 +76,7 @@ public class SpotController {
 
     @Schema(description = "스팟 UPDATE 요청/응답 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PatchMapping(value = "/spot/update",
+    @PatchMapping(value = "/private/spot/update",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<SpotResponseDto> spotUpdate(@RequestPart(value = "data")
@@ -88,7 +88,7 @@ public class SpotController {
     }
 
     @Schema(description = "스팟 DELETE 요청")
-    @DeleteMapping("/spot/{spotId}/delete")
+    @DeleteMapping("/private/spot/{spotId}/delete")
     public Result spotDelete(@PathVariable("spotId") Long spotId) {
         spotService.deleteSpot(spotId);
 

--- a/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotMultiReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotMultiReadResponseDto.java
@@ -35,10 +35,6 @@ public class SpotMultiReadResponseDto {
     //유저 객체 추가 필요
 
 
-    // 프론트엔드측과 의논 후 추가 여부 결정
-    //private List<RecentReviewsDto> recentReviewDtos;
-
-
     // 유저 객체 전달 필요
     @Schema(description = "스팟 생성일")
     private LocalDateTime createAt;

--- a/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotSingleReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotSingleReadResponseDto.java
@@ -33,7 +33,10 @@ public class SpotSingleReadResponseDto {
     private int views;
 
     @Schema(description = "단일 스팟의 모든 리뷰 평균 평점")
-    private String ratingAvg;
+    private Double ratingAvg;
+
+    @Schema(description = "장소 리뷰 수")
+    private Integer reviewCounts;
 
     //유저 객체 추가 필요
 

--- a/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
@@ -52,7 +52,8 @@ public class SpotService {
                 .build();
         spot.setLocation(location);
         spotRepository.save(spot);
-        spot.createSpotImage(imageService.uploadImages(images));
+        spot.createSpotImage(imageService.uploadImageFacade(images));
+        imageService.uploadImages(images);
 
         return SpotResponseDto
                 .builder()
@@ -162,7 +163,7 @@ public class SpotService {
                 spotRequestDto.getSpotId())
                 .orElseThrow(() -> new ApiException(SpotErrorCode.SPOT_NOT_FOUND));
 
-        spot.updateSpot(spotRequestDto, imageService.updateImages(
+        spot.updateSpot(spotRequestDto, imageService.updateImageFacade(
                 images, spotRequestDto.getDeleteImages()));
 
         return SpotResponseDto
@@ -205,7 +206,7 @@ public class SpotService {
         Spot findSpot = spotRepository.findById(id)
                 .orElseThrow(() -> new ApiException(SpotErrorCode.SPOT_NOT_FOUND));
         spotRepository.deleteById(findSpot.getId());
-        imageService.deleteAllImages(findSpot.getImages());
+        imageService.deleteAllImagesFacade(findSpot.getImages());
     }
 
 

--- a/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
@@ -121,8 +121,10 @@ public class SpotService {
                 .latitude(spot.getLatitude())
                 .longitude(spot.getLongitude())
                 .images(spot.getImages())
-                .ratingAvg(String.format("%.2f", ratingAverage(spot.getReviews())))
+                .ratingAvg(Double.parseDouble
+                        (String.format("%.2f", ratingAverage(spot.getReviews()))))
                 .recentReviewDtos(reviews)
+                .reviewCounts(spot.getReviews().size() < 100 ? spot.getReviews().size(): 99)
                 .build();
     }
 

--- a/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
@@ -1,10 +1,9 @@
 package trendravel.photoravel_be.domain.spot.service;
 
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import trendravel.photoravel_be.commom.error.ErrorCode;
 import trendravel.photoravel_be.commom.error.LocationErrorCode;
 import trendravel.photoravel_be.commom.error.SpotErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
@@ -35,6 +34,7 @@ public class SpotService {
     private final LocationRepository locationRepository;
     private final ImageService imageService;
 
+    @Transactional
     public SpotResponseDto createSpot(
             SpotRequestDto spotRequestDto, List<MultipartFile> images) {
 
@@ -67,6 +67,7 @@ public class SpotService {
                 .build();
     }
 
+    @Transactional
     public SpotResponseDto createSpot(
             SpotRequestDto spotRequestDto) {
         Location location = locationRepository.findById(spotRequestDto.
@@ -97,16 +98,16 @@ public class SpotService {
     }
 
 
-    @Transactional
+    @Transactional(readOnly = true)
     public SpotSingleReadResponseDto readSingleSpot(Long locationId, Long spotId) {
         List<Spot> spots = locationRepository.findById(locationId)
                 .map(Location::getSpot)
                 .orElseThrow(() -> new ApiException(LocationErrorCode.LOCATION_NOT_FOUND));
 
-
         Spot spot = spots.stream().
                 filter(s -> s.getId().equals(spotId)).findFirst()
                 .orElseThrow(() -> new ApiException(SpotErrorCode.SPOT_NOT_FOUND));
+        spot.increaseViews();
 
         List<RecentReviewsDto> reviews = spotRepository.recentReviews(spot.getId());
 
@@ -125,7 +126,7 @@ public class SpotService {
                 .build();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<SpotMultiReadResponseDto> readMultiSpot(Long locationId) {
         List<Spot> spots = locationRepository.findById(locationId)
                 .map(Location::getSpot)

--- a/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
@@ -48,11 +48,11 @@ public class SpotService {
                 .title(spotRequestDto.getTitle())
                 .latitude(spotRequestDto.getLatitude())
                 .longitude(spotRequestDto.getLongitude())
-                .images(imageService.uploadImages(images))
                 .location(location)
                 .build();
         spot.setLocation(location);
         spotRepository.save(spot);
+        spot.createSpotImage(imageService.uploadImages(images));
 
         return SpotResponseDto
                 .builder()

--- a/src/test/java/trendravel/photoravel_be/service/LocationServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/service/LocationServiceTest.java
@@ -226,9 +226,9 @@ class LocationServiceTest {
         assertThat(locationSingleReadResponseDto.getAddress())
                 .isEqualTo(findLocation.getAddress());
         assertThat(locationSingleReadResponseDto.getRatingAvg())
-                .isEqualTo(String.format("%.2f",
+                .isEqualTo(Double.parseDouble(String.format("%.2f",
                         (review4.getRating() + review2.getRating()
-                                + review3.getRating() + review1.getRating()) / 4));
+                                + review3.getRating() + review1.getRating()) / 4)));
         assertThat(locationSingleReadResponseDto.getViews()).isEqualTo(1);
         assertThat(findRecentReviews).extracting("rating")
                 .containsExactlyInAnyOrder(review4.getRating(),
@@ -315,6 +315,31 @@ class LocationServiceTest {
                 .hasMessageContaining(LocationErrorCode.LOCATION_NOT_FOUND.getErrorDescription());
     }
 
+    @DisplayName("LOCATION의 리뷰 수가 100개 이상일 때, 99개로 변경하여 잘 보내는지 테스트")
+    @Test
+    @Transactional
+    @Order(9)
+    void locationReviewCountsMoreThanOneHundredTest(){
+
+        for (int i = 0; i < 1000; i++) {
+            review1.setLocationReview(location);
+            reviewRepository.save(review1);
+        }
+        Long id = locationRepository.save(location).getId();
+
+        assertThat(locationService.readSingleLocation(id).getReviewCounts()).isEqualTo(99);
+    }
+
+    @DisplayName("LOCATION의 리뷰 수가 100개 이하일 때, 그 개수를 그대로 READ하는지 테스트")
+    @Test
+    @Transactional
+    @Order(10)
+    void locationReviewCountsLessThanOneHundredTest(){
+        Long id = locationRepository.save(location).getId();
+
+        assertThat(locationService.readSingleLocation(id).getReviewCounts())
+                .isEqualTo(location.getReview().size());
+    }
 
 
 }

--- a/src/test/java/trendravel/photoravel_be/service/SpotServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/service/SpotServiceTest.java
@@ -71,6 +71,7 @@ class SpotServiceTest {
                 .latitude(35.24)
                 .longitude(46.61)
                 .address("아산시 신창면 순천향로46")
+                .description("순천향대학교입니다.")
                 .point(new GeometryFactory().createPoint(
                         new Coordinate(35.24
                                 , 46.61)))
@@ -229,7 +230,7 @@ class SpotServiceTest {
                 .isEqualTo(String.format("%.2f",
                         (review4.getRating() + review2.getRating()
                                 + review3.getRating() + review1.getRating()) / 4));
-        assertThat(spotSingleReadResponseDto.getViews()).isEqualTo(0);
+        assertThat(spotSingleReadResponseDto.getViews()).isEqualTo(1);
         assertThat(findRecentReviews.size()).isGreaterThan(1);
         assertThat(findRecentReviews).extracting("rating")
                 .containsExactlyInAnyOrder(review4.getRating(),

--- a/src/test/java/trendravel/photoravel_be/service/SpotServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/service/SpotServiceTest.java
@@ -227,9 +227,9 @@ class SpotServiceTest {
         assertThat(spotSingleReadResponseDto.getTitle())
                 .isEqualTo(findSpot.getTitle());
         assertThat(spotSingleReadResponseDto.getRatingAvg())
-                .isEqualTo(String.format("%.2f",
+                .isEqualTo(Double.parseDouble(String.format("%.2f",
                         (review4.getRating() + review2.getRating()
-                                + review3.getRating() + review1.getRating()) / 4));
+                                + review3.getRating() + review1.getRating()) / 4)));
         assertThat(spotSingleReadResponseDto.getViews()).isEqualTo(1);
         assertThat(findRecentReviews.size()).isGreaterThan(1);
         assertThat(findRecentReviews).extracting("rating")
@@ -289,6 +289,36 @@ class SpotServiceTest {
         assertThatThrownBy(() -> spotService.deleteSpot(100L))
                 .isInstanceOf(ApiException.class)
                 .hasMessageContaining(SpotErrorCode.SPOT_NOT_FOUND.getErrorDescription());
+    }
+
+    @DisplayName("SPOT의 리뷰 수가 100개 이상일 때, 99개로 변경하여 잘 보내는지 테스트")
+    @Test
+    @Transactional
+    @Order(10)
+    void locationReviewCountsMoreThanOneHundredTest(){
+        Long locationId = locationRepository.save(location).getId();
+        for (int i = 0; i < 1000; i++) {
+            review1.setSpotReview(spot);
+            reviewRepository.save(review1);
+        }
+        spot.setLocation(location);
+        Long id = spotRepository.save(spot).getId();
+
+        assertThat(spotService.readSingleSpot(locationId, id).getReviewCounts())
+                .isEqualTo(99);
+    }
+
+    @DisplayName("SPOT의 리뷰 수가 100개 이하일 때, 그 개수를 그대로 READ하는지 테스트")
+    @Test
+    @Transactional
+    @Order(11)
+    void locationReviewCountsLessThanOneHundredTest(){
+        Long locationId = locationRepository.save(location).getId();
+        spot.setLocation(location);
+        Long id = spotRepository.save(spot).getId();
+
+        assertThat(spotService.readSingleSpot(locationId, id).getReviewCounts())
+                .isEqualTo(location.getReview().size());
     }
 
 


### PR DESCRIPTION
# 문제 발생
- Transaction내에서 DB 저장 Rollback 발생 시, S3 Stroage의 이미지 복구 및 삭제가 안되는 문제 발생
- Transactional의 DB Rollback되기 전 S3에서 이미지를 먼저 저장하거나 삭제하기 때문에 발생하는 문제
- 검증 기능 추가와 함께 S3 Rollback 문제가 빈번해짐
- PATCH 로직에서는 작동하지 않음

# 문제 해결을 위한 고민
- DB 저장 이후, S3에 저장하는 방법 고민
- 해당 방법으로 변경할 경우, ImagePath 저장에 대해 변경 필요
- 코드가 복잡해져서 ImageService를 사용하기 편하도록 리팩토링 필요

# 선택한 해결 방법
- Spring Event를 사용하여, S3에 저장하는 시점을 Transactional에서의 모든 작업이 끝나고 COMMIT된 이후로 설정
- Transaction에서 Rollback 발생 시, S3에 Trash 이미지가 남는 문제 방지
- DB에 저장될 ImagePath는 직접 ImageService의 해당 메소드를 사용하여, 미리 저장함

# 테스트 결과
## LOCATION CREATE 테스트 (예시로 Rollback 예외가 터진다 가정)
![20240903_000835](https://github.com/user-attachments/assets/8ac48a68-2b78-483b-9984-a8049eb3f048)
## 중간 Rollback Exception 발생으로 DB에 저장되지 않으면서 S3에도 저장되지 않음
![20240903_000918](https://github.com/user-attachments/assets/9d81617a-8e1d-4651-851c-942a0f03c565)
![20240903_000929](https://github.com/user-attachments/assets/99d7bf63-bbb1-4518-8c09-2e51eedb94eb)
## LOCATION CREATE 테스트 (예외 안 터질때)
### 문제 없이 이벤트가 작동하여 DB와 S3 모두 저장됨
![20240903_000947](https://github.com/user-attachments/assets/765bb437-c9a5-4f69-a9e7-644f6e101842)
![20240903_001221](https://github.com/user-attachments/assets/886962b4-1dab-451f-acea-685d3ca7157f)
![20240903_000954](https://github.com/user-attachments/assets/fea78a25-247c-4560-bf91-63dc266c7c4c)

## LOCATION PATCH 테스트 (예시로 Rollback 예외가 터진다 가정)
### 예외 발생 후, DB와 S3  모두 변경되지 않음
![20240903_001152](https://github.com/user-attachments/assets/776ea07b-ca97-4282-8e56-b9fa5d476cdd)
![20240903_001207](https://github.com/user-attachments/assets/fd6fb179-1d65-46c5-90a4-a8d0c2c66a1f)
![20240903_001227](https://github.com/user-attachments/assets/4d2b3c56-c375-430d-8a5a-80546115f858)
### 정상 로직일 경우 DB와 S3 모두 변경됨
![20240903_001241](https://github.com/user-attachments/assets/c10c4281-eef4-44ff-9975-2fe81b5c2a2f)


# 남은 문제
- PATCH 서비스에서는 이벤트가 적용되지 않은 문제 발생
- Could not JPA Commit 예외와 함께, Validation 예외가 nested Exception 되어, 검증에 대한 예외가 잡히지 않음
- Dirty Check의 작동 원리 때문에 발생하는 문제라 생각.
- Transcational이 끝난 이후 Commit하는 시점에서 발생하기에 이미지가 작동하지 않는다고 추측
- 따라서 Validation의 사용 시점을 변경할 필요가 있다 생각하게됨
