### PR TITLE
[Refactor] ImageService와 Facade패턴 적용 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ out/
 *.properties
 *.yml
 src/main/generated
+src/main/resources
 
 ### NetBeans ###
 /nbproject/private/

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'mysql:mysql-connector-java:8.0.32'
 	implementation 'io.minio:minio:8.5.11'
 	implementation 'io.findify:s3mock_2.13:0.2.6'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	//Querydsl 추가
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,9 @@ dependencies {
 	implementation 'org.locationtech.jts:jts-core:1.18.2'
 	implementation 'mysql:mysql-connector-java:8.0.32'
 	implementation 'io.minio:minio:8.5.11'
-	implementation 'io.findify:s3mock_2.13:0.2.6'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation(platform("software.amazon.awssdk:bom:2.21.1"))
+	implementation("software.amazon.awssdk:s3")
 
 	//Querydsl 추가
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/trendravel/photoravel_be/commom/error/ErrorCode.java
+++ b/src/main/java/trendravel/photoravel_be/commom/error/ErrorCode.java
@@ -20,7 +20,10 @@ public enum ErrorCode implements ErrorCodeIfs{
     UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED.value(), "인증 안 됨"),
     IMAGES_NOT_FOUND(404, "이미지 없음"),
     IMAGES_UPLOAD_ERROR(500, "이미지 저장소 업로드 실패"),
-    ENUM_TYPE_NOT_READABLE(400, "잘못된 ENUM 타입 전달, [LOCATION, SPOT, GUIDE] 중 하나로 보낼 것");
+    HTTP_INPUT_NOT_READABLE(400, "잘못된 HTTP 입력 요청"),
+    ENUM_TYPE_NOT_READABLE(400, "잘못된 ENUM 타입 전달, [LOCATION, SPOT, GUIDE] 중 하나로 보낼 것"),
+    INPUT_FORMAT_ERROR(400, "잘못된 타입의 입력 요청"),
+    IMAGE_SIZE_EXCEED_ERROR(400, "요청 이미지 최대 용량 초과");
 
     private final Integer httpStatusCode;   // 클라이언트에 보여줄 status code
     private final String errorDescription;  // 에러 설명

--- a/src/main/java/trendravel/photoravel_be/commom/error/ErrorCode.java
+++ b/src/main/java/trendravel/photoravel_be/commom/error/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode implements ErrorCodeIfs{
     FORBIDDEN_ERROR(HttpStatus.FORBIDDEN.value(), "권한 없음"),
     UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED.value(), "인증 안 됨"),
     IMAGES_NOT_FOUND(404, "이미지 없음"),
-    IMAGES_UPLOAD_ERROR(500, "이미지 저장소 업로드 실패");
+    IMAGES_UPLOAD_ERROR(500, "이미지 저장소 업로드 실패"),
+    ENUM_TYPE_NOT_READABLE(400, "잘못된 ENUM 타입 전달, [LOCATION, SPOT, GUIDE] 중 하나로 보낼 것");
 
     private final Integer httpStatusCode;   // 클라이언트에 보여줄 status code
     private final String errorDescription;  // 에러 설명

--- a/src/main/java/trendravel/photoravel_be/commom/event/ImageDeleteEvent.java
+++ b/src/main/java/trendravel/photoravel_be/commom/event/ImageDeleteEvent.java
@@ -1,0 +1,14 @@
+package trendravel.photoravel_be.commom.event;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ImageDeleteEvent {
+    private List<String> deleteImages = new ArrayList<>();
+}

--- a/src/main/java/trendravel/photoravel_be/commom/event/ImageUploadEvent.java
+++ b/src/main/java/trendravel/photoravel_be/commom/event/ImageUploadEvent.java
@@ -1,0 +1,15 @@
+package trendravel.photoravel_be.commom.event;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ImageUploadEvent {
+    private List<MultipartFile> uploadImages = new ArrayList<>();
+}

--- a/src/main/java/trendravel/photoravel_be/commom/eventHandler/ImageServiceEventHandler.java
+++ b/src/main/java/trendravel/photoravel_be/commom/eventHandler/ImageServiceEventHandler.java
@@ -1,0 +1,36 @@
+package trendravel.photoravel_be.commom.eventHandler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import trendravel.photoravel_be.commom.event.ImageUploadEvent;
+import trendravel.photoravel_be.commom.event.ImageDeleteEvent;
+import trendravel.photoravel_be.commom.image.service.ImageService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ImageServiceEventHandler {
+
+    private final ImageService imageService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleImageUploadExceptionEventListener(ImageUploadEvent imageUploadEvent){
+        log.info("DB 저장 성공, S3 저장 이미지 저장");
+        imageService.uploadImages(imageUploadEvent.getUploadImages());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleImageDeleteExceptionEventListener(ImageDeleteEvent imageDeleteEvent){
+        log.info("DB 저장 성공, S3 이미지 삭제");
+        imageService.deleteAllImages(imageDeleteEvent.getDeleteImages());
+    }
+
+
+}

--- a/src/main/java/trendravel/photoravel_be/commom/exceptionhandler/ApiExHandler.java
+++ b/src/main/java/trendravel/photoravel_be/commom/exceptionhandler/ApiExHandler.java
@@ -1,13 +1,20 @@
 package trendravel.photoravel_be.commom.exceptionhandler;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSourceResolvable;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import trendravel.photoravel_be.commom.error.ErrorCodeIfs;
 import trendravel.photoravel_be.commom.exception.ApiException;
 import trendravel.photoravel_be.commom.response.Api;
+
+import static trendravel.photoravel_be.commom.error.ErrorCode.*;
 
 @RestControllerAdvice
 @Slf4j
@@ -25,7 +32,71 @@ public class ApiExHandler {
         return ResponseEntity
             .status(errorCodeIfs.getHttpStatusCode())
             .body(
-                    Api.ERROR(errorCodeIfs.getHttpStatusCode(), apiException.getErrorDescription())
+                    Api.ERROR(errorCodeIfs.getHttpStatusCode(),
+                            apiException.getErrorDescription())
             );
     }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ResponseEntity<Api<Object>> methodArgumentNotValidExceptionHandler(
+            MethodArgumentNotValidException e
+    ){
+
+        log.info("{}",e.getBindingResult().
+                getFieldError()
+                .getDefaultMessage());
+
+
+        return ResponseEntity
+                .status(e.getStatusCode())
+                .body(
+                        Api.NOT_VALID(INPUT_FORMAT_ERROR.getHttpStatusCode(),
+                                e.getBindingResult().
+                                        getFieldError()
+                                        .getDefaultMessage()
+                        )
+                );
+    }
+
+    @ExceptionHandler(value = HandlerMethodValidationException.class)
+    public ResponseEntity<Api<?>> handlerMethodValidationExceptionHandler(
+            HandlerMethodValidationException e
+    ){
+
+        log.info("{}",e.getAllValidationResults().get(0).getResolvableErrors()
+                .stream()
+                .map(MessageSourceResolvable::getDefaultMessage)
+                .toList());
+
+        return ResponseEntity
+                .status(INPUT_FORMAT_ERROR.getHttpStatusCode())
+                .body(Api.ERROR(INPUT_FORMAT_ERROR.getHttpStatusCode(),
+                        e.getAllValidationResults().get(0).getResolvableErrors()
+                                .stream()
+                                .map(MessageSourceResolvable::getDefaultMessage)
+                                .toList()
+                                .toString()
+                ));
+    }
+
+    @ExceptionHandler(value = HttpMessageNotReadableException.class)
+    public ResponseEntity<Api<?>> httpMessageNotReadableExceptionHandler(
+            HttpMessageNotReadableException e
+    ){
+
+        return ResponseEntity
+                .status(HTTP_INPUT_NOT_READABLE.getHttpStatusCode())
+                .body(Api.ERROR(HTTP_INPUT_NOT_READABLE.getHttpStatusCode(),
+                        HTTP_INPUT_NOT_READABLE.getErrorDescription()));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<Api<?>> maxUploadSizeExceededExceptionHandler(){
+        return ResponseEntity
+                .status(IMAGE_SIZE_EXCEED_ERROR.getHttpStatusCode())
+                .body(Api.ERROR(IMAGE_SIZE_EXCEED_ERROR.getHttpStatusCode(),
+                        IMAGE_SIZE_EXCEED_ERROR.getErrorDescription()
+                ));
+    }
+
 }

--- a/src/main/java/trendravel/photoravel_be/commom/exceptionhandler/GlobalExHandler.java
+++ b/src/main/java/trendravel/photoravel_be/commom/exceptionhandler/GlobalExHandler.java
@@ -5,7 +5,6 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import trendravel.photoravel_be.commom.error.ErrorCode;
@@ -14,8 +13,6 @@ import trendravel.photoravel_be.commom.response.Api;
 
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static trendravel.photoravel_be.commom.error.ErrorCode.ENUM_TYPE_NOT_READABLE;
 
 @RestControllerAdvice
 @Order(value = Integer.MAX_VALUE)
@@ -63,17 +60,7 @@ public class GlobalExHandler {
     }
 
 
-    @ExceptionHandler(value = HttpMessageNotReadableException.class)
-    public ResponseEntity<Api<?>> httpMessageNotReadableExceptionHandler(
-            HttpMessageNotReadableException e
-    ){
 
-
-        return ResponseEntity
-                .status(500)
-                .body(Api.ERROR(ENUM_TYPE_NOT_READABLE.getHttpStatusCode(),
-                        ENUM_TYPE_NOT_READABLE.getErrorDescription()));
-    }
 
 
 

--- a/src/main/java/trendravel/photoravel_be/commom/exceptionhandler/GlobalExHandler.java
+++ b/src/main/java/trendravel/photoravel_be/commom/exceptionhandler/GlobalExHandler.java
@@ -1,13 +1,21 @@
 package trendravel.photoravel_be.commom.exceptionhandler;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import trendravel.photoravel_be.commom.error.ErrorCode;
 import trendravel.photoravel_be.commom.exception.ImageSystemException;
 import trendravel.photoravel_be.commom.response.Api;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static trendravel.photoravel_be.commom.error.ErrorCode.ENUM_TYPE_NOT_READABLE;
 
 @RestControllerAdvice
 @Order(value = Integer.MAX_VALUE)
@@ -38,4 +46,35 @@ public class GlobalExHandler {
                                 , imageSystemException.getErrorDescription())
                 );
     }
+
+    @ExceptionHandler(value = ConstraintViolationException.class)
+    public ResponseEntity<Api<?>> validationExceptionHandler(
+            ConstraintViolationException e
+    ){
+
+        ArrayList<String> errors = e.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        return ResponseEntity
+                .status(500)
+                .body(Api.ERROR(500,
+                        errors.stream().toList().toString()));
+    }
+
+
+    @ExceptionHandler(value = HttpMessageNotReadableException.class)
+    public ResponseEntity<Api<?>> httpMessageNotReadableExceptionHandler(
+            HttpMessageNotReadableException e
+    ){
+
+
+        return ResponseEntity
+                .status(500)
+                .body(Api.ERROR(ENUM_TYPE_NOT_READABLE.getHttpStatusCode(),
+                        ENUM_TYPE_NOT_READABLE.getErrorDescription()));
+    }
+
+
+
 }

--- a/src/main/java/trendravel/photoravel_be/commom/exceptionhandler/GlobalExHandler.java
+++ b/src/main/java/trendravel/photoravel_be/commom/exceptionhandler/GlobalExHandler.java
@@ -57,8 +57,8 @@ public class GlobalExHandler {
                 .collect(Collectors.toCollection(ArrayList::new));
 
         return ResponseEntity
-                .status(500)
-                .body(Api.ERROR(500,
+                .status(400)
+                .body(Api.ERROR(400,
                         errors.stream().toList().toString()));
     }
 

--- a/src/main/java/trendravel/photoravel_be/commom/image/service/ImageService.java
+++ b/src/main/java/trendravel/photoravel_be/commom/image/service/ImageService.java
@@ -1,62 +1,34 @@
 package trendravel.photoravel_be.commom.image.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 import trendravel.photoravel_be.commom.error.ErrorCode;
-import trendravel.photoravel_be.commom.event.ImageUploadEvent;
-import trendravel.photoravel_be.commom.event.ImageDeleteEvent;
 import trendravel.photoravel_be.commom.exception.ImageSystemException;
 import trendravel.photoravel_be.commom.image.util.ImageNameRebuildUtils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class ImageService {
+public class ImageService{
 
 
     private final S3Client amazonS3;
     private final S3Client minioClient;
 
-    private final ApplicationEventPublisher eventPublisher;
+
 
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
-
-    @Transactional
-    public List<String> uploadImageFacade(List<MultipartFile> imageFiles) {
-        eventPublisher.publishEvent(new ImageUploadEvent(imageFiles));
-        return getImagesName(imageFiles);
-    }
-
-    @Transactional
-    public List<String> updateImageFacade(List<MultipartFile> newImages,
-                                          List<String> deleteImages){
-        eventPublisher.publishEvent(new ImageDeleteEvent(deleteImages));
-        eventPublisher.publishEvent(new ImageUploadEvent(newImages));
-        if(newImages == null || newImages.isEmpty()){
-            return new ArrayList<>();
-        }
-
-        return getImagesName(newImages);
-    }
-
-    @Transactional
-    public void deleteAllImagesFacade(List<String> deleteImages){
-        eventPublisher.publishEvent(new ImageDeleteEvent(deleteImages));
-    }
 
     public void uploadImages(List<MultipartFile> images){
         if(images == null){
@@ -119,7 +91,7 @@ public class ImageService {
     }
 
 
-    private List<String> getImagesName(List<MultipartFile> multipartFiles){
+    List<String> getImagesName(List<MultipartFile> multipartFiles){
         return multipartFiles.stream()
                 .map(p-> ImageNameRebuildUtils
                         .buildImageName(p.getOriginalFilename()))

--- a/src/main/java/trendravel/photoravel_be/commom/image/service/ImageService.java
+++ b/src/main/java/trendravel/photoravel_be/commom/image/service/ImageService.java
@@ -1,14 +1,18 @@
 package trendravel.photoravel_be.commom.image.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 import trendravel.photoravel_be.commom.error.ErrorCode;
+import trendravel.photoravel_be.commom.event.ImageUploadEvent;
+import trendravel.photoravel_be.commom.event.ImageDeleteEvent;
 import trendravel.photoravel_be.commom.exception.ImageSystemException;
 import trendravel.photoravel_be.commom.image.util.ImageNameRebuildUtils;
 
@@ -26,18 +30,40 @@ public class ImageService {
     private final S3Client amazonS3;
     private final S3Client minioClient;
 
+    private final ApplicationEventPublisher eventPublisher;
+
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
 
+    @Transactional
+    public List<String> uploadImageFacade(List<MultipartFile> imageFiles) {
+        eventPublisher.publishEvent(new ImageUploadEvent(imageFiles));
+        return getImagesName(imageFiles);
+    }
 
-    public List<String> uploadImages(List<MultipartFile> images){
-
-        if(images == null){
-            return null;
+    @Transactional
+    public List<String> updateImageFacade(List<MultipartFile> newImages,
+                                          List<String> deleteImages){
+        eventPublisher.publishEvent(new ImageDeleteEvent(deleteImages));
+        eventPublisher.publishEvent(new ImageUploadEvent(newImages));
+        if(newImages == null || newImages.isEmpty()){
+            return new ArrayList<>();
         }
 
-//        return uploadImagesAndReturnUrl(images, amazonS3);
-        return uploadImagesAndReturnUrl(images, minioClient);
+        return getImagesName(newImages);
+    }
+
+    @Transactional
+    public void deleteAllImagesFacade(List<String> deleteImages){
+        eventPublisher.publishEvent(new ImageDeleteEvent(deleteImages));
+    }
+
+    public void uploadImages(List<MultipartFile> images){
+        if(images == null){
+            return;
+        }
+        uploadImagesAndReturnUrl(images, minioClient);
+//      uploadImagesAndReturnUrl(images, amazonS3);
     }
 
 
@@ -61,33 +87,28 @@ public class ImageService {
         return rebuildImageName;
     }
 
-    public List<String> updateImages(List<MultipartFile> newImages,
-                                     List<String> deleteImages){
-
-        deleteAllImages(deleteImages);
-
-        if(newImages == null){
-            return new ArrayList<>();
-        }
 
 
-//        return uploadImagesAndReturnUrl(newImages, amazonS3);
-        return uploadImagesAndReturnUrl(newImages, minioClient);
-    }
-
+    /**
+     * db에 들어있는 경우만 지우기!
+     */
 
     public void deleteAllImages(List<String> deleteImages){
+        deleteImagesInStorage(deleteImages, minioClient);
+//        deleteImagesInStorage(deleteImages, amazonS3);
+    }
+
+    private void deleteImagesInStorage(List<String> deleteImages, S3Client storage) {
         List<String> imageNames = sliceUrlAndGetImageNames(deleteImages);
         log.info("{}", imageNames.get(0));
         for (String imageName : imageNames) {
-//            amazonS3.deleteObject(bucketName, imageName);
             log.info("{}", imageName);
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest
                     .builder()
                     .bucket(bucketName)
                     .key(imageName)
                     .build();
-            minioClient.deleteObject(deleteObjectRequest);
+            storage.deleteObject(deleteObjectRequest);
         }
     }
 
@@ -98,7 +119,7 @@ public class ImageService {
     }
 
 
-    public List<String> getImagesName(List<MultipartFile> multipartFiles){
+    private List<String> getImagesName(List<MultipartFile> multipartFiles){
         return multipartFiles.stream()
                 .map(p-> ImageNameRebuildUtils
                         .buildImageName(p.getOriginalFilename()))

--- a/src/main/java/trendravel/photoravel_be/commom/image/service/ImageServiceFacade.java
+++ b/src/main/java/trendravel/photoravel_be/commom/image/service/ImageServiceFacade.java
@@ -1,0 +1,44 @@
+package trendravel.photoravel_be.commom.image.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import trendravel.photoravel_be.commom.event.ImageDeleteEvent;
+import trendravel.photoravel_be.commom.event.ImageUploadEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ImageServiceFacade {
+
+    private final ApplicationEventPublisher eventPublisher;
+    private final ImageService imageService;
+
+    @Transactional
+    public List<String> uploadImageFacade(List<MultipartFile> imageFiles) {
+        eventPublisher.publishEvent(new ImageUploadEvent(imageFiles));
+        return imageService.getImagesName(imageFiles);
+    }
+
+    @Transactional
+    public List<String> updateImageFacade(List<MultipartFile> newImages,
+                                          List<String> deleteImages){
+        eventPublisher.publishEvent(new ImageDeleteEvent(deleteImages));
+        eventPublisher.publishEvent(new ImageUploadEvent(newImages));
+        if(newImages == null || newImages.isEmpty()){
+            return new ArrayList<>();
+        }
+
+        return imageService.getImagesName(newImages);
+    }
+
+    @Transactional
+    public void deleteAllImagesFacade(List<String> deleteImages){
+        eventPublisher.publishEvent(new ImageDeleteEvent(deleteImages));
+    }
+
+}

--- a/src/main/java/trendravel/photoravel_be/commom/image/valid/ImageSizeValid.java
+++ b/src/main/java/trendravel/photoravel_be/commom/image/valid/ImageSizeValid.java
@@ -1,0 +1,20 @@
+package trendravel.photoravel_be.commom.image.valid;
+
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Constraint(validatedBy = ImageSizeValidator.class)
+@Target(value = {ElementType.TYPE, ElementType.PARAMETER})
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface ImageSizeValid {
+    String message() default "한번에 요청 할 수 있는 최대 이미지 개수(10개) 초과 또는 이미지 미전송 (null)";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/trendravel/photoravel_be/commom/image/valid/ImageSizeValidator.java
+++ b/src/main/java/trendravel/photoravel_be/commom/image/valid/ImageSizeValidator.java
@@ -1,0 +1,18 @@
+package trendravel.photoravel_be.commom.image.valid;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public class ImageSizeValidator implements ConstraintValidator<ImageSizeValid, List<MultipartFile>> {
+
+    @Override
+    public boolean isValid(List<MultipartFile> multipartFiles,
+                           ConstraintValidatorContext constraintValidatorContext) {
+
+
+        return multipartFiles != null && multipartFiles.size() <= 10;
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/commom/response/Api.java
+++ b/src/main/java/trendravel/photoravel_be/commom/response/Api.java
@@ -62,8 +62,15 @@ public class Api<T> {
         return response;
     }
 
-    // validation용 ERROR
+
     public static Api<Object> ERROR(Integer errorCode, String errorDescription) {
+        Api<Object> response = new Api<>();
+        response.result = Result.ERROR(errorCode, errorDescription);
+        return response;
+    }
+
+
+    public static Api<Object> NOT_VALID(Integer errorCode, String errorDescription) {
         Api<Object> response = new Api<>();
         response.result = Result.ERROR(errorCode, errorDescription);
         return response;

--- a/src/main/java/trendravel/photoravel_be/config/S3Config.java
+++ b/src/main/java/trendravel/photoravel_be/config/S3Config.java
@@ -1,15 +1,14 @@
 package trendravel.photoravel_be.config;
 
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.*;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.net.URI;
 
 @Configuration
 public class S3Config {
@@ -34,21 +33,26 @@ public class S3Config {
 
 
     @Bean
-    public AmazonS3 amazonS3(){
-        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, accessSecret);
-        return AmazonS3ClientBuilder
-                .standard()
-                .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+    public S3Client amazonS3(){
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider
+                        .create(AwsBasicCredentials
+                                .create(accessKey, accessSecret)))
                 .build();
     }
 
+
+
     @Bean
-    public AmazonS3 minioClient(){
-        return AmazonS3ClientBuilder.standard()
-                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(minioUrl, region))
-                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(minioAccessKey, minioSecretKey)))
-                .withPathStyleAccessEnabled(true)
+    public S3Client minioClient(){
+        return S3Client.builder()
+                .endpointOverride(URI.create(minioUrl))
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider
+                        .create(AwsBasicCredentials
+                                .create(minioAccessKey, minioSecretKey)))
+                .forcePathStyle(true)
                 .build();
     }
 

--- a/src/main/java/trendravel/photoravel_be/db/guide/Guide.java
+++ b/src/main/java/trendravel/photoravel_be/db/guide/Guide.java
@@ -53,7 +53,7 @@ public class Guide extends BaseEntity {
         this.profileImg = images.get(0);
     }
     
-    @OneToMany(mappedBy = "guideReview")
+    @OneToMany(mappedBy = "guideReview", orphanRemoval = true)
     @Builder.Default
     private List<Review> reviews = new ArrayList<>();
     

--- a/src/main/java/trendravel/photoravel_be/db/location/Location.java
+++ b/src/main/java/trendravel/photoravel_be/db/location/Location.java
@@ -2,7 +2,11 @@ package trendravel.photoravel_be.db.location;
 
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.hibernate.validator.constraints.Length;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import trendravel.photoravel_be.db.BaseEntity;
@@ -18,9 +22,12 @@ import java.util.List;
 @Entity
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-@Table(name = "LOCATION")
+@Table(name = "LOCATION", indexes = {
+        @Index(name = "idx__point", columnList = "point"),
+        @Index(name = "idx__point__name", columnList = "name")
+})
 public class Location extends BaseEntity {
 
     @Id
@@ -28,13 +35,22 @@ public class Location extends BaseEntity {
     @Column(name = "location_id")
     private Long id;
 
-
-    private double latitude;
-    private double longitude;
+    @NotNull(message = "필수 입력사항입니다.")
+    private Double latitude;
+    @NotNull(message = "필수 입력사항입니다.")
+    private Double longitude;
+    @Column(length = 50)
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 50, message = "최대 길이는 50글자입니다.")
     private String address;
 
     @Column(columnDefinition = "TEXT")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
     private String description;
+
+    @Column(length = 50)
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 50, message = "최대 길이는 50글자입니다.")
     private String name;
 
     @Column(columnDefinition = "POINT SRID 4326", nullable = false)
@@ -45,6 +61,7 @@ public class Location extends BaseEntity {
             name = "location_images",
             joinColumns = @JoinColumn(name = "location_id")
     )
+    @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
     private List<String> images = new ArrayList<>();
     private int views;
 

--- a/src/main/java/trendravel/photoravel_be/db/location/Location.java
+++ b/src/main/java/trendravel/photoravel_be/db/location/Location.java
@@ -62,6 +62,7 @@ public class Location extends BaseEntity {
             joinColumns = @JoinColumn(name = "location_id")
     )
     @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
+    @Builder.Default
     private List<String> images = new ArrayList<>();
     private int views;
 
@@ -76,6 +77,11 @@ public class Location extends BaseEntity {
     @Builder.Default
     private List<Review> review = new ArrayList<>();
 
+    public void createLocationImage(List<String> imageNames){
+        images.addAll(imageNames);
+    }
+
+
     public void updateLocation(LocationUpdateImagesDto location, List<String> newImages){
         this.longitude = location.getLongitude();
         this.latitude = location.getLatitude();
@@ -85,9 +91,7 @@ public class Location extends BaseEntity {
         this.point = new GeometryFactory()
                 .createPoint(new Coordinate(latitude, longitude));
         this.point.setSRID(4326);
-        for (String deleteImage : location.getDeleteImages()) {
-            this.images.remove(deleteImage);
-        }
+        this.images.removeAll(location.getDeleteImages());
         this.images.addAll(newImages);
     }
 

--- a/src/main/java/trendravel/photoravel_be/db/location/Location.java
+++ b/src/main/java/trendravel/photoravel_be/db/location/Location.java
@@ -35,22 +35,15 @@ public class Location extends BaseEntity {
     @Column(name = "location_id")
     private Long id;
 
-    @NotNull(message = "필수 입력사항입니다.")
     private Double latitude;
-    @NotNull(message = "필수 입력사항입니다.")
     private Double longitude;
     @Column(length = 50)
-    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
-    @Length(max = 50, message = "최대 길이는 50글자입니다.")
     private String address;
 
     @Column(columnDefinition = "TEXT")
-    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
     private String description;
 
     @Column(length = 50)
-    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
-    @Length(max = 50, message = "최대 길이는 50글자입니다.")
     private String name;
 
     @Column(columnDefinition = "POINT SRID 4326", nullable = false)
@@ -61,7 +54,6 @@ public class Location extends BaseEntity {
             name = "location_images",
             joinColumns = @JoinColumn(name = "location_id")
     )
-    @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
     @Builder.Default
     private List<String> images = new ArrayList<>();
     private int views;
@@ -76,10 +68,6 @@ public class Location extends BaseEntity {
     @OneToMany(mappedBy = "locationReview", orphanRemoval = true)
     @Builder.Default
     private List<Review> review = new ArrayList<>();
-
-    public void createLocationImage(List<String> imageNames){
-        images.addAll(imageNames);
-    }
 
 
     public void updateLocation(LocationUpdateImagesDto location, List<String> newImages){

--- a/src/main/java/trendravel/photoravel_be/db/review/Review.java
+++ b/src/main/java/trendravel/photoravel_be/db/review/Review.java
@@ -2,7 +2,9 @@ package trendravel.photoravel_be.db.review;
 
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
 import lombok.*;
+import org.hibernate.validator.constraints.Length;
 import trendravel.photoravel_be.db.BaseEntity;
 import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.db.spot.Spot;
@@ -15,7 +17,7 @@ import java.util.List;
 @Entity
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Table(name = "REVIEW")
 public class Review extends BaseEntity {
@@ -28,15 +30,22 @@ public class Review extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ReviewTypes reviewType;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(length = 500)
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 500, message = "최대 길이는 500자 입니다.")
     private String content;
-    private double rating;
+
+    @DecimalMax(value = "5.0", message = "최대 허용 별점은 5.0입니다.")
+    @DecimalMin(value = "1.0", message = "최소 허용 별점은 1.0입니다.")
+    @NotNull(message = "필수 입력사항입니다.")
+    private Double rating;
 
     @ElementCollection
     @CollectionTable(
             name = "review_images",
             joinColumns = @JoinColumn(name = "review_id")
     )
+    @Size(max = 10)
     private List<String> images;
 
     // 회원, 가이드 관련 연관관계 필드 추가 필요

--- a/src/main/java/trendravel/photoravel_be/db/review/Review.java
+++ b/src/main/java/trendravel/photoravel_be/db/review/Review.java
@@ -4,8 +4,8 @@ package trendravel.photoravel_be.db.review;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.*;
-import org.hibernate.validator.constraints.Length;
 import trendravel.photoravel_be.db.BaseEntity;
+import trendravel.photoravel_be.db.guide.Guide;
 import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.db.spot.Spot;
 import trendravel.photoravel_be.domain.review.dto.request.ReviewRequestDto;
@@ -32,12 +32,8 @@ public class Review extends BaseEntity {
     private ReviewTypes reviewType;
 
     @Column(length = 500)
-    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
-    @Length(max = 500, message = "최대 길이는 500자 입니다.")
     private String content;
 
-    @DecimalMax(value = "5.0", message = "최대 허용 별점은 5.0입니다.")
-    @DecimalMin(value = "1.0", message = "최소 허용 별점은 1.0입니다.")
     @NotNull(message = "필수 입력사항입니다.")
     private Double rating;
 
@@ -46,7 +42,6 @@ public class Review extends BaseEntity {
             name = "review_images",
             joinColumns = @JoinColumn(name = "review_id")
     )
-    @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
     @Builder.Default
     private List<String> images = new ArrayList<>();
 
@@ -61,10 +56,10 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "spot_id")
     private Spot spotReview;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guide_id")
+    private Guide guideReview;
 
-    public void createReviewImage(List<String> imageNames){
-        images.addAll(imageNames);
-    }
 
 
     //연관관계 편의 메소드

--- a/src/main/java/trendravel/photoravel_be/db/review/Review.java
+++ b/src/main/java/trendravel/photoravel_be/db/review/Review.java
@@ -12,6 +12,7 @@ import trendravel.photoravel_be.domain.review.dto.request.ReviewRequestDto;
 import trendravel.photoravel_be.db.review.enums.ReviewTypes;
 import trendravel.photoravel_be.domain.review.dto.request.ReviewUpdateImagesDto;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -45,8 +46,8 @@ public class Review extends BaseEntity {
             name = "review_images",
             joinColumns = @JoinColumn(name = "review_id")
     )
-    @Size(max = 10)
-    private List<String> images;
+    @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
+    private List<String> images = new ArrayList<>();
 
     // 회원, 가이드 관련 연관관계 필드 추가 필요
 

--- a/src/main/java/trendravel/photoravel_be/db/review/Review.java
+++ b/src/main/java/trendravel/photoravel_be/db/review/Review.java
@@ -47,6 +47,7 @@ public class Review extends BaseEntity {
             joinColumns = @JoinColumn(name = "review_id")
     )
     @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
+    @Builder.Default
     private List<String> images = new ArrayList<>();
 
     // 회원, 가이드 관련 연관관계 필드 추가 필요
@@ -59,6 +60,12 @@ public class Review extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "spot_id")
     private Spot spotReview;
+
+
+    public void createReviewImage(List<String> imageNames){
+        images.addAll(imageNames);
+    }
+
 
     //연관관계 편의 메소드
     public void setSpotReview(Spot spot) {

--- a/src/main/java/trendravel/photoravel_be/db/review/enums/ReviewTypes.java
+++ b/src/main/java/trendravel/photoravel_be/db/review/enums/ReviewTypes.java
@@ -1,17 +1,11 @@
 package trendravel.photoravel_be.db.review.enums;
 
 
-
+/**
+ *
+ */
 public enum ReviewTypes {
-    LOCATION("관광장소", "1"),
-    SPOT("사진스팟","2"),
-    GUIDE("가이드", "3");
-
-    private final String title;
-    private final String typeCode;
-
-    ReviewTypes(String title, String typeCode) {
-        this.title = title;
-        this.typeCode = typeCode;
-    }
+    LOCATION,
+    SPOT,
+    GUIDE;
 }

--- a/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
+++ b/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.hibernate.validator.constraints.Length;
 import trendravel.photoravel_be.db.BaseEntity;
 import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.domain.spot.dto.request.SpotRequestDto;
@@ -28,7 +29,9 @@ public class Spot extends BaseEntity {
     @Column(name = "spot_id")
     private Long id;
 
+    @Column(length = 50)
     @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 50, message="최대 길이는 50자 입니다.")
     private String title;
 
     @Column(columnDefinition = "TEXT")
@@ -47,7 +50,7 @@ public class Spot extends BaseEntity {
             joinColumns = @JoinColumn(name = "spot_id")
     )
     @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
-    private List<String> images;
+    private List<String> images = new ArrayList<>();
 
 
 

--- a/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
+++ b/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
@@ -30,17 +30,12 @@ public class Spot extends BaseEntity {
     private Long id;
 
     @Column(length = 50)
-    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
-    @Length(max = 50, message="최대 길이는 50자 입니다.")
     private String title;
 
     @Column(columnDefinition = "TEXT")
-    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
     private String description;
 
-    @NotNull(message = "필수 입력사항입니다.")
     private Double latitude;
-    @NotNull(message = "필수 입력사항입니다.")
     private Double longitude;
     private int views;
 
@@ -49,7 +44,6 @@ public class Spot extends BaseEntity {
             name = "spot_image",
             joinColumns = @JoinColumn(name = "spot_id")
     )
-    @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
     @Builder.Default
     private List<String> images = new ArrayList<>();
 
@@ -64,10 +58,6 @@ public class Spot extends BaseEntity {
     @OneToMany(mappedBy = "spotReview", orphanRemoval = true)
     @Builder.Default
     private List<Review> reviews = new ArrayList<>();
-
-    public void createSpotImage(List<String> imageNames){
-        images.addAll(imageNames);
-    }
 
     //연관관계 편의 메소드
     public void setLocation(Location location){

--- a/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
+++ b/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
@@ -50,8 +50,8 @@ public class Spot extends BaseEntity {
             joinColumns = @JoinColumn(name = "spot_id")
     )
     @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
+    @Builder.Default
     private List<String> images = new ArrayList<>();
-
 
 
     //유저 엔티티 생성 후, 연관관계 필드 추가 필요
@@ -64,6 +64,10 @@ public class Spot extends BaseEntity {
     @OneToMany(mappedBy = "spotReview", orphanRemoval = true)
     @Builder.Default
     private List<Review> reviews = new ArrayList<>();
+
+    public void createSpotImage(List<String> imageNames){
+        images.addAll(imageNames);
+    }
 
     //연관관계 편의 메소드
     public void setLocation(Location location){

--- a/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
+++ b/src/main/java/trendravel/photoravel_be/db/spot/Spot.java
@@ -2,6 +2,9 @@ package trendravel.photoravel_be.db.spot;
 
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 import trendravel.photoravel_be.db.BaseEntity;
 import trendravel.photoravel_be.db.location.Location;
@@ -15,7 +18,7 @@ import java.util.List;
 @Entity
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Table(name = "SPOT")
 public class Spot extends BaseEntity {
@@ -25,13 +28,17 @@ public class Spot extends BaseEntity {
     @Column(name = "spot_id")
     private Long id;
 
-
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
     private String title;
 
     @Column(columnDefinition = "TEXT")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
     private String description;
-    private double latitude;
-    private double longitude;
+
+    @NotNull(message = "필수 입력사항입니다.")
+    private Double latitude;
+    @NotNull(message = "필수 입력사항입니다.")
+    private Double longitude;
     private int views;
 
     @ElementCollection
@@ -39,6 +46,7 @@ public class Spot extends BaseEntity {
             name = "spot_image",
             joinColumns = @JoinColumn(name = "spot_id")
     )
+    @Size(max = 10, message = "한번에 들어올 수 있는 이미지는 10개입니다")
     private List<String> images;
 
 

--- a/src/main/java/trendravel/photoravel_be/domain/guide/service/GuideService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/guide/service/GuideService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.error.ErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
-import trendravel.photoravel_be.commom.service.ImageService;
+import trendravel.photoravel_be.commom.image.service.ImageService;
 import trendravel.photoravel_be.db.guide.Guide;
 import trendravel.photoravel_be.db.respository.guide.GuideRepository;
 import trendravel.photoravel_be.db.review.Review;
@@ -101,8 +101,12 @@ public class GuideService {
         }
         
         Guide guide = guideOpt.get();
-        guide.updateGuide(guideRequestDto, imageService.uploadImages(images));
-        
+
+        /**
+         * 삭제할 이미지 리스트 필요, 에러 발생으로 주석처리. 수정 필요
+         */
+//        guide.updateGuide(guideRequestDto, imageService.updateImageFacade(images));
+        imageService.uploadImages(images);
         //List<RecentReviewsDto> reviews = guideRepository.recentReviews(guide.getId());
         
         return GuideResponseDto.builder()

--- a/src/main/java/trendravel/photoravel_be/domain/guidebook/service/GuidebookService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/guidebook/service/GuidebookService.java
@@ -4,12 +4,12 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import trendravel.photoravel_be.commom.image.service.ImageService;
 import trendravel.photoravel_be.domain.guidebook.dto.request.GuidebookRequestDto;
 import trendravel.photoravel_be.domain.guidebook.dto.response.GuidebookResponseDto;
 import trendravel.photoravel_be.db.guidebook.Guidebook;
 import trendravel.photoravel_be.db.enums.Region;
 import trendravel.photoravel_be.db.respository.guidebook.GuidebookRepository;
-import trendravel.photoravel_be.commom.service.ImageService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,11 +33,11 @@ public class GuidebookService {
                 .title(guidebookRequestDto.getTitle())
                 .content(guidebookRequestDto.getContent())
                 .region(guidebookRequestDto.getRegion())
-                .images(imageService.uploadImages(images))
+                .images(imageService.uploadImageFacade(images))
                 .views(0)
                 .build());
-        
-        
+
+        imageService.uploadImages(images);
         return GuidebookResponseDto.builder()
                 .id(guidebook.getId())
                 .userId(guidebook.getUserId())
@@ -137,8 +137,12 @@ public class GuidebookService {
         }
         
         Guidebook guidebook = guidebookOpt.get();
-        guidebook.updateGuidebook(guidebookRequestDto, imageService.uploadImages(images));
-        
+
+        /**
+         * 삭제 이미지 리스트 필요, 수정 필요.
+         */
+//        guidebook.updateGuidebook(guidebookRequestDto, imageService.updateImageFacade(images));
+        imageService.uploadImages(images);
         return GuidebookResponseDto.builder()
                 .id(guidebook.getId())
                 .userId(guidebook.getUserId())

--- a/src/main/java/trendravel/photoravel_be/domain/guidebook/service/GuidebookService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/guidebook/service/GuidebookService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.image.service.ImageService;
+import trendravel.photoravel_be.commom.image.service.ImageServiceFacade;
 import trendravel.photoravel_be.domain.guidebook.dto.request.GuidebookRequestDto;
 import trendravel.photoravel_be.domain.guidebook.dto.response.GuidebookResponseDto;
 import trendravel.photoravel_be.db.guidebook.Guidebook;
@@ -21,7 +22,7 @@ import java.util.Optional;
 public class GuidebookService {
     
     private final GuidebookRepository guidebookRepository;
-    private final ImageService imageService;
+    private final ImageServiceFacade imageServiceFacade;
     
     @Transactional
     public GuidebookResponseDto createGuidebook(
@@ -33,11 +34,11 @@ public class GuidebookService {
                 .title(guidebookRequestDto.getTitle())
                 .content(guidebookRequestDto.getContent())
                 .region(guidebookRequestDto.getRegion())
-                .images(imageService.uploadImageFacade(images))
+                .images(imageServiceFacade.uploadImageFacade(images))
                 .views(0)
                 .build());
 
-        imageService.uploadImages(images);
+
         return GuidebookResponseDto.builder()
                 .id(guidebook.getId())
                 .userId(guidebook.getUserId())
@@ -142,7 +143,6 @@ public class GuidebookService {
          * 삭제 이미지 리스트 필요, 수정 필요.
          */
 //        guidebook.updateGuidebook(guidebookRequestDto, imageService.updateImageFacade(images));
-        imageService.uploadImages(images);
         return GuidebookResponseDto.builder()
                 .id(guidebook.getId())
                 .userId(guidebook.getUserId())

--- a/src/main/java/trendravel/photoravel_be/domain/location/controller/LocationController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/controller/LocationController.java
@@ -29,7 +29,7 @@ public class LocationController {
 
     @Schema(description = "장소 CREATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PostMapping(value = "/location/create")
+    @PostMapping(value = "/private/location/create")
     public Api<LocationResponseDto> locationCreate(@RequestBody
                                            LocationRequestDto locationRequestDto) {
 
@@ -38,7 +38,7 @@ public class LocationController {
 
     @Schema(description = "장소 CREATE 요청/응답 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PostMapping(value = "/location/create",
+    @PostMapping(value = "/private/location/create",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<LocationResponseDto> locationCreate(@RequestPart(value = "data")
@@ -90,7 +90,7 @@ public class LocationController {
 
     @Schema(description = "장소 UPDATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PatchMapping(value = "/location/update")
+    @PatchMapping(value = "/private/location/update")
     public Api<LocationResponseDto> locationUpdate(@RequestBody
                                                        LocationRequestDto locationRequestDto) {
 
@@ -100,7 +100,7 @@ public class LocationController {
 
     @Schema(description = "장소 UPDATE 요청/응답 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PatchMapping(value = "/location/update",
+    @PatchMapping(value = "/private/location/update",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<LocationResponseDto> locationUpdate(@RequestPart(value = "data")
@@ -114,7 +114,7 @@ public class LocationController {
 
 
     @Schema(description = "장소 DELETE 요청/응답")
-    @DeleteMapping("/location/{locationId}/delete")
+    @DeleteMapping("/private/location/{locationId}/delete")
     public Result locationDelete(@PathVariable("locationId") Long locationId) {
         locationService.deleteLocation(locationId);
 

--- a/src/main/java/trendravel/photoravel_be/domain/location/controller/LocationController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/controller/LocationController.java
@@ -2,10 +2,12 @@ package trendravel.photoravel_be.domain.location.controller;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import trendravel.photoravel_be.commom.image.valid.ImageSizeValid;
 import trendravel.photoravel_be.commom.response.Api;
 import trendravel.photoravel_be.commom.response.Result;
 import trendravel.photoravel_be.domain.location.dto.request.LocationKeywordDto;
@@ -31,7 +33,7 @@ public class LocationController {
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
     @PostMapping(value = "/private/location/create")
     public Api<LocationResponseDto> locationCreate(@RequestBody
-                                           LocationRequestDto locationRequestDto) {
+            @Valid LocationRequestDto locationRequestDto) {
 
         return Api.CREATED(locationService.createLocation(locationRequestDto));
     }
@@ -42,7 +44,8 @@ public class LocationController {
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<LocationResponseDto> locationCreate(@RequestPart(value = "data")
-                                               LocationRequestDto locationRequestDto,
+            @Valid LocationRequestDto locationRequestDto,
+                                           @ImageSizeValid
                                            @RequestPart(value = "images", required = false)
                                                 List<MultipartFile> images) {
 
@@ -91,8 +94,9 @@ public class LocationController {
     @Schema(description = "장소 UPDATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
     @PatchMapping(value = "/private/location/update")
-    public Api<LocationResponseDto> locationUpdate(@RequestBody
-                                                       LocationRequestDto locationRequestDto) {
+    public Api<LocationResponseDto> locationUpdate(
+            @Valid @RequestBody
+            LocationRequestDto locationRequestDto) {
 
         return Api.UPDATED(locationService.updateLocation(locationRequestDto));
     }
@@ -103,8 +107,10 @@ public class LocationController {
     @PatchMapping(value = "/private/location/update",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public Api<LocationResponseDto> locationUpdate(@RequestPart(value = "data")
-                                                       LocationUpdateImagesDto locationRequestDto,
+    public Api<LocationResponseDto> locationUpdate(
+            @RequestPart(value = "data")
+            @Valid LocationUpdateImagesDto locationRequestDto,
+                                           @ImageSizeValid
                                            @RequestPart(value = "images", required = false)
                                                 List<MultipartFile> images) {
 

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/request/LocationRequestDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/request/LocationRequestDto.java
@@ -1,7 +1,10 @@
 package trendravel.photoravel_be.domain.location.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.MediaType;
 
 
@@ -13,14 +16,21 @@ public class LocationRequestDto {
     @Schema(description = "장소ID")
     private Long locationId;
     @Schema(description = "위도")
+    @NotNull(message = "필수 입력사항입니다.")
     private double latitude;
     @Schema(description = "경도")
+    @NotNull(message = "필수 입력사항입니다.")
     private double longitude;
     @Schema(description = "주소")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 50, message = "최대 길이는 50글자입니다.")
     private String address;
     @Schema(description = "설명")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
     private String description;
     @Schema(description = "이름")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 50, message = "최대 길이는 50글자입니다.")
     private String name;
     @Schema(description = "유저명")
     private String userId;

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/request/LocationUpdateImagesDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/request/LocationUpdateImagesDto.java
@@ -1,7 +1,11 @@
 package trendravel.photoravel_be.domain.location.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.MediaType;
 
 import java.util.List;
@@ -15,14 +19,21 @@ public class LocationUpdateImagesDto {
     @Schema(description = "장소ID")
     private Long locationId;
     @Schema(description = "위도")
+    @NotNull(message = "필수 입력사항입니다.")
     private double latitude;
     @Schema(description = "경도")
+    @NotNull(message = "필수 입력사항입니다.")
     private double longitude;
     @Schema(description = "주소")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 50, message = "최대 길이는 50글자입니다.")
     private String address;
     @Schema(description = "설명")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
     private String description;
     @Schema(description = "이름")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 50, message = "최대 길이는 50글자입니다.")
     private String name;
     @Schema(description = "유저명")
     private String userId;

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationMultiReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationMultiReadResponseDto.java
@@ -34,7 +34,9 @@ public class LocationMultiReadResponseDto {
     @Schema(description = "장소별 조회수")
     private int views;
     @Schema(description = "장소 리뷰 평균 평점")
-    private String ratingAvg;
+    private Double ratingAvg;
+    @Schema(description = "장소 리뷰 수")
+    private Integer reviewCounts;
 
     //유저 객체 추가 필요
 

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationMultiReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationMultiReadResponseDto.java
@@ -40,8 +40,6 @@ public class LocationMultiReadResponseDto {
 
     //유저 객체 추가 필요
 
-    // 프론트엔드측과 의논 후 추가 여부 결정
-    // private List<RecentReviewsDto> recentReviewDtos;
 
     @Schema(description = "장소 생성일")
     private LocalDateTime createAt;

--- a/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationSingleReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/dto/response/LocationSingleReadResponseDto.java
@@ -33,7 +33,9 @@ public class LocationSingleReadResponseDto {
     @Schema(description = "장소 조회수")
     private int views;
     @Schema(description = "장소 리뷰 평균 평점")
-    private String ratingAvg;
+    private Double ratingAvg;
+    @Schema(description = "장소 리뷰 수")
+    private Integer reviewCounts;
 
     //유저 객체 추가 필요
     @Schema(description = "최근 업데이트된 리뷰 목록 (최대 3개)")

--- a/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.error.LocationErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
+import trendravel.photoravel_be.commom.image.service.ImageServiceFacade;
 import trendravel.photoravel_be.db.review.Review;
 import trendravel.photoravel_be.domain.location.dto.request.LocationKeywordDto;
 import trendravel.photoravel_be.domain.location.dto.request.LocationNowPositionDto;
@@ -22,7 +23,7 @@ import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.db.respository.location.LocationRepository;
 import trendravel.photoravel_be.domain.location.dto.response.LocationSingleReadResponseDto;
 import trendravel.photoravel_be.domain.review.dto.response.RecentReviewsDto;
-import trendravel.photoravel_be.commom.image.service.ImageService;
+
 
 import java.util.List;
 
@@ -37,7 +38,7 @@ import java.util.List;
 public class LocationService {
 
     private final LocationRepository locationRepository;
-    private final ImageService imageService;
+    private final ImageServiceFacade imageServiceFacade;
 
     @Transactional
     public LocationResponseDto createLocation(
@@ -46,7 +47,7 @@ public class LocationService {
         Location location = Location.builder()
                 .description(locationRequestDto.getDescription())
                 .name(locationRequestDto.getName())
-                .images(imageService.uploadImageFacade(images))
+                .images(imageServiceFacade.uploadImageFacade(images))
                 .latitude(locationRequestDto.getLatitude())
                 .longitude(locationRequestDto.getLongitude())
                 .address(locationRequestDto.getAddress())
@@ -184,7 +185,7 @@ public class LocationService {
                 .orElseThrow(() -> new ApiException(LocationErrorCode.LOCATION_NOT_FOUND));
         log.info("이미지 저장 전");
         location.updateLocation(locationRequestDto,
-                imageService.updateImageFacade(images, locationRequestDto.getDeleteImages()));
+                imageServiceFacade.updateImageFacade(images, locationRequestDto.getDeleteImages()));
         log.info("이미지 저장 후");
 
         return LocationResponseDto
@@ -230,7 +231,7 @@ public class LocationService {
         Location findLocation = locationRepository.findById(id)
                 .orElseThrow(() -> new ApiException(LocationErrorCode.LOCATION_NOT_FOUND));
         locationRepository.deleteById(findLocation.getId());
-        imageService.deleteAllImagesFacade(findLocation.getImages());
+        imageServiceFacade.deleteAllImagesFacade(findLocation.getImages());
     }
 
 }

--- a/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
@@ -1,11 +1,12 @@
 package trendravel.photoravel_be.domain.location.service;
 
 
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.error.LocationErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
@@ -98,7 +99,7 @@ public class LocationService {
                 .build();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public LocationSingleReadResponseDto readSingleLocation(Long id){
         Location location = locationRepository.findById(id)
                 .orElseThrow(() -> new ApiException(LocationErrorCode.LOCATION_NOT_FOUND));
@@ -123,7 +124,7 @@ public class LocationService {
                 .build();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<LocationMultiReadResponseDto> readMultiLocation(
             LocationNowPositionDto locationNowPositionDto){
         List<Location> locations =
@@ -140,7 +141,7 @@ public class LocationService {
                 .toList();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<LocationMultiReadResponseDto> readMultiLocation(
             LocationKeywordDto locationKeywordDto){
         List<Location> locations = locationRepository.searchKeyword(locationKeywordDto);

--- a/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/location/service/LocationService.java
@@ -1,5 +1,6 @@
 package trendravel.photoravel_be.domain.location.service;
 
+
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.locationtech.jts.geom.Coordinate;
@@ -45,7 +46,6 @@ public class LocationService {
                 .latitude(locationRequestDto.getLatitude())
                 .longitude(locationRequestDto.getLongitude())
                 .address(locationRequestDto.getAddress())
-                .images(imageService.uploadImages(images))
                 .views(0)
                 .point(new GeometryFactory().createPoint(
                                 new Coordinate(locationRequestDto.getLatitude()
@@ -53,6 +53,8 @@ public class LocationService {
                 .build();
         location.getPoint().setSRID(4326);
         locationRepository.save(location);
+        location.createLocationImage(imageService.uploadImages(images));
+
 
         return LocationResponseDto
                 .builder()

--- a/src/main/java/trendravel/photoravel_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/controller/ReviewController.java
@@ -2,10 +2,12 @@ package trendravel.photoravel_be.domain.review.controller;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import trendravel.photoravel_be.commom.image.valid.ImageSizeValid;
 import trendravel.photoravel_be.commom.response.Api;
 import trendravel.photoravel_be.commom.response.Result;
 import trendravel.photoravel_be.domain.review.dto.request.ReviewRequestDto;
@@ -26,7 +28,7 @@ public class ReviewController {
     @Schema(description = "리뷰 CREATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
     @PostMapping(value = "/private/review/create")
-    public Api<ReviewResponseDto> createReview(@RequestBody
+    public Api<ReviewResponseDto> createReview(@RequestBody @Valid
                                                    ReviewRequestDto reviewRequestDto){
 
         return Api.CREATED(reviewService.createReview(reviewRequestDto));
@@ -37,8 +39,9 @@ public class ReviewController {
     @PostMapping(value = "/private/review/create",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public Api<ReviewResponseDto> createReview(@RequestPart(value = "data")
+    public Api<ReviewResponseDto> createReview(@RequestPart(value = "data") @Valid
                                              ReviewRequestDto reviewRequestDto,
+                                         @ImageSizeValid
                                          @RequestPart(value = "images", required = false)
                                             List<MultipartFile> images){
 
@@ -65,7 +68,7 @@ public class ReviewController {
     @Schema(description = "리뷰 UPDATE 요청 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
     @PatchMapping(value = "/private/review/update")
-    public Api<ReviewResponseDto> updateReview(@RequestBody
+    public Api<ReviewResponseDto> updateReview(@RequestBody @Valid
                                                ReviewRequestDto reviewRequestDto){
 
         return Api.UPDATED(reviewService.updateReview(reviewRequestDto));
@@ -76,8 +79,9 @@ public class ReviewController {
     @PatchMapping(value = "/private/review/update",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public Api<ReviewResponseDto> updateReview(@RequestPart(value = "data")
+    public Api<ReviewResponseDto> updateReview(@RequestPart(value = "data") @Valid
                                                    ReviewUpdateImagesDto reviewRequestDto,
+                                         @ImageSizeValid
                                          @RequestPart(value = "images", required = false)
                                             List<MultipartFile> images){
 

--- a/src/main/java/trendravel/photoravel_be/domain/review/controller/ReviewController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/controller/ReviewController.java
@@ -25,7 +25,7 @@ public class ReviewController {
 
     @Schema(description = "리뷰 CREATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PostMapping(value = "/review/create")
+    @PostMapping(value = "/private/review/create")
     public Api<ReviewResponseDto> createReview(@RequestBody
                                                    ReviewRequestDto reviewRequestDto){
 
@@ -34,7 +34,7 @@ public class ReviewController {
 
     @Schema(description = "리뷰 CREATE 요청/응답 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PostMapping(value = "/review/create",
+    @PostMapping(value = "/private/review/create",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<ReviewResponseDto> createReview(@RequestPart(value = "data")
@@ -64,7 +64,7 @@ public class ReviewController {
 
     @Schema(description = "리뷰 UPDATE 요청 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PatchMapping(value = "/review/update")
+    @PatchMapping(value = "/private/review/update")
     public Api<ReviewResponseDto> updateReview(@RequestBody
                                                ReviewRequestDto reviewRequestDto){
 
@@ -73,7 +73,7 @@ public class ReviewController {
 
     @Schema(description = "리뷰 UPDATE 요청 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PatchMapping(value = "/review/update",
+    @PatchMapping(value = "/private/review/update",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<ReviewResponseDto> updateReview(@RequestPart(value = "data")
@@ -85,7 +85,7 @@ public class ReviewController {
     }
 
     @Schema(description = "리뷰 DELETE 요청")
-    @DeleteMapping(value ="/review/{reviewId}/delete")
+    @DeleteMapping(value ="/private/review/{reviewId}/delete")
     public Result locationDelete(@PathVariable("reviewId") Long reviewId) {
         reviewService.deleteReview(reviewId);
 

--- a/src/main/java/trendravel/photoravel_be/domain/review/dto/request/ReviewRequestDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/dto/request/ReviewRequestDto.java
@@ -2,7 +2,11 @@ package trendravel.photoravel_be.domain.review.dto.request;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.MediaType;
 import trendravel.photoravel_be.db.review.enums.ReviewTypes;
 
@@ -18,8 +22,12 @@ public class ReviewRequestDto {
     @Schema(description = "리뷰타입")
     private ReviewTypes reviewType;
     @Schema(description = "리뷰내용")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 500, message = "최대 길이는 500자 입니다.")
     private String content;
     @Schema(description = "리뷰평점")
+    @DecimalMax(value = "5.0", message = "최대 허용 별점은 5.0입니다.")
+    @DecimalMin(value = "1.0", message = "최소 허용 별점은 1.0입니다.")
     private double rating;
     @Schema(description = "유저아이디")
     private String userId;

--- a/src/main/java/trendravel/photoravel_be/domain/review/dto/request/ReviewUpdateImagesDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/dto/request/ReviewUpdateImagesDto.java
@@ -2,7 +2,11 @@ package trendravel.photoravel_be.domain.review.dto.request;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.MediaType;
 import trendravel.photoravel_be.db.review.enums.ReviewTypes;
 
@@ -19,8 +23,12 @@ public class ReviewUpdateImagesDto {
     @Schema(description = "리뷰타입")
     private ReviewTypes reviewType;
     @Schema(description = "리뷰내용")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 500, message = "최대 길이는 500자 입니다.")
     private String content;
     @Schema(description = "리뷰평점")
+    @DecimalMax(value = "5.0", message = "최대 허용 별점은 5.0입니다.")
+    @DecimalMin(value = "1.0", message = "최소 허용 별점은 1.0입니다.")
     private double rating;
     @Schema(description = "유저아이디")
     private String userId;

--- a/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
@@ -52,9 +52,8 @@ public class ReviewService {
                     .orElseThrow(() -> new ApiException(SpotErrorCode.SPOT_NOT_FOUND));
         }
 
-        Review review = reviewRepository.save(Review.builder()
+        Review review = Review.builder()
                 .reviewType(reviewRequestDto.getReviewType())
-                .images(imageService.uploadImages(images))
                 .content(reviewRequestDto.getContent())
                 .rating(reviewRequestDto.getRating())
                 .locationReview(ReviewTypes.LOCATION ==
@@ -63,10 +62,12 @@ public class ReviewService {
                 .spotReview(ReviewTypes.SPOT ==
                         reviewRequestDto.getReviewType()
                         ? spot : null)
-                .build());
+                .build();
 
         review.setLocationReview(location);
         review.setSpotReview(spot);
+        reviewRepository.save(review);
+        review.createReviewImage(imageService.uploadImages(images));
 
         return ReviewResponseDto
                 .builder()
@@ -98,7 +99,7 @@ public class ReviewService {
         }
 
 
-        Review review = reviewRepository.save(Review.builder()
+        Review review = Review.builder()
                 .reviewType(reviewRequestDto.getReviewType())
                 .content(reviewRequestDto.getContent())
                 .rating(reviewRequestDto.getRating())
@@ -108,7 +109,7 @@ public class ReviewService {
                 .spotReview(ReviewTypes.SPOT ==
                         reviewRequestDto.getReviewType()
                         ? spot : null)
-                .build());
+                .build();
 
 
         /**
@@ -120,7 +121,7 @@ public class ReviewService {
             review.setLocationReview(location);
         }
 
-
+        reviewRepository.save(review);
 
 
         return ReviewResponseDto

--- a/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
@@ -1,10 +1,10 @@
 package trendravel.photoravel_be.domain.review.service;
 
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import trendravel.photoravel_be.commom.error.ErrorCode;
 import trendravel.photoravel_be.commom.error.LocationErrorCode;
 import trendravel.photoravel_be.commom.error.ReviewErrorCode;
 import trendravel.photoravel_be.commom.error.SpotErrorCode;
@@ -32,6 +32,7 @@ public class ReviewService {
     private final LocationRepository locationRepository;
     private final ImageService imageService;
 
+    @Transactional
     public ReviewResponseDto createReview(
             ReviewRequestDto reviewRequestDto, List<MultipartFile> images) {
 
@@ -79,6 +80,7 @@ public class ReviewService {
                 .build();
     }
 
+    @Transactional
     public ReviewResponseDto createReview(
             ReviewRequestDto reviewRequestDto) {
 
@@ -132,7 +134,7 @@ public class ReviewService {
                 .build();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ReviewResponseDto> readAllLocationReview(Long locationId){
         List<Review> reviews = locationRepository.findById(locationId)
                 .map(Location::getReview)
@@ -145,7 +147,7 @@ public class ReviewService {
                 .toList();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ReviewResponseDto> readAllSpotReview(Long locationId, Long spotId){
         List<Spot> spots = locationRepository.findById(locationId)
                 .map(Location::getSpot)

--- a/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
@@ -10,6 +10,7 @@ import trendravel.photoravel_be.commom.error.ReviewErrorCode;
 import trendravel.photoravel_be.commom.error.SpotErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
 import trendravel.photoravel_be.commom.image.service.ImageService;
+import trendravel.photoravel_be.commom.image.service.ImageServiceFacade;
 import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.db.spot.Spot;
 import trendravel.photoravel_be.domain.review.dto.request.ReviewRequestDto;
@@ -30,7 +31,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final SpotRepository spotRepository;
     private final LocationRepository locationRepository;
-    private final ImageService imageService;
+    private final ImageServiceFacade imageServiceFacade;
 
     @Transactional
     public ReviewResponseDto createReview(
@@ -62,14 +63,13 @@ public class ReviewService {
                 .spotReview(ReviewTypes.SPOT ==
                         reviewRequestDto.getReviewType()
                         ? spot : null)
-                .images(imageService.uploadImageFacade(images))
+                .images(imageServiceFacade.uploadImageFacade(images))
                 .build();
 
         review.setLocationReview(location);
         review.setSpotReview(spot);
         reviewRepository.save(review);
 
-        imageService.uploadImages(images);
         return ReviewResponseDto
                 .builder()
                 .ReviewId(review.getId())
@@ -177,7 +177,7 @@ public class ReviewService {
                 reviewRequestDto.getReviewId())
                 .orElseThrow(() -> new ApiException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
-        review.updateReview(reviewRequestDto, imageService.updateImageFacade(images,
+        review.updateReview(reviewRequestDto, imageServiceFacade.updateImageFacade(images,
                 reviewRequestDto.getDeleteImages()));
 
         return ReviewResponseDto
@@ -219,7 +219,7 @@ public class ReviewService {
         Review findReview = reviewRepository.findById(id)
                 .orElseThrow(() -> new ApiException(ReviewErrorCode.REVIEW_NOT_FOUND));
         reviewRepository.deleteById(findReview.getId());
-        imageService.deleteAllImagesFacade(findReview.getImages());
+        imageServiceFacade.deleteAllImagesFacade(findReview.getImages());
     }
 
 }

--- a/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/review/service/ReviewService.java
@@ -62,13 +62,14 @@ public class ReviewService {
                 .spotReview(ReviewTypes.SPOT ==
                         reviewRequestDto.getReviewType()
                         ? spot : null)
+                .images(imageService.uploadImageFacade(images))
                 .build();
 
         review.setLocationReview(location);
         review.setSpotReview(spot);
         reviewRepository.save(review);
-        review.createReviewImage(imageService.uploadImages(images));
 
+        imageService.uploadImages(images);
         return ReviewResponseDto
                 .builder()
                 .ReviewId(review.getId())
@@ -176,7 +177,7 @@ public class ReviewService {
                 reviewRequestDto.getReviewId())
                 .orElseThrow(() -> new ApiException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
-        review.updateReview(reviewRequestDto, imageService.updateImages(images,
+        review.updateReview(reviewRequestDto, imageService.updateImageFacade(images,
                 reviewRequestDto.getDeleteImages()));
 
         return ReviewResponseDto
@@ -218,7 +219,7 @@ public class ReviewService {
         Review findReview = reviewRepository.findById(id)
                 .orElseThrow(() -> new ApiException(ReviewErrorCode.REVIEW_NOT_FOUND));
         reviewRepository.deleteById(findReview.getId());
-        imageService.deleteAllImages(findReview.getImages());
+        imageService.deleteAllImagesFacade(findReview.getImages());
     }
 
 }

--- a/src/main/java/trendravel/photoravel_be/domain/spot/controller/SpotController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/controller/SpotController.java
@@ -2,10 +2,12 @@ package trendravel.photoravel_be.domain.spot.controller;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import trendravel.photoravel_be.commom.image.valid.ImageSizeValid;
 import trendravel.photoravel_be.commom.response.Api;
 import trendravel.photoravel_be.commom.response.Result;
 import trendravel.photoravel_be.domain.spot.dto.request.SpotRequestDto;
@@ -24,13 +26,11 @@ public class SpotController {
 
     private final SpotService spotService;
 
-
-
     @Schema(description = "스팟 CREATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
     @PostMapping(value = "/private/spot/create")
     public Api<SpotResponseDto> spotCreate(@RequestBody
-                                       SpotRequestDto spotRequestDto){
+            @Valid SpotRequestDto spotRequestDto){
 
         return Api.CREATED(spotService.createSpot(spotRequestDto));
     }
@@ -41,7 +41,8 @@ public class SpotController {
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<SpotResponseDto> spotCreate(@RequestPart(value = "data")
-                                           SpotRequestDto spotRequestDto,
+            @Valid SpotRequestDto spotRequestDto,
+                                           @ImageSizeValid
                                            @RequestPart(value = "images", required = false)
                                            List<MultipartFile> images){
 
@@ -68,7 +69,7 @@ public class SpotController {
     @Schema(description = "스팟 UPDATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
     @PatchMapping(value = "/private/spot/update")
-    public Api<SpotResponseDto> spotUpdate(@RequestBody
+    public Api<SpotResponseDto> spotUpdate(@RequestBody @Valid
                                        SpotRequestDto spotRequestDto) {
 
         return Api.UPDATED(spotService.updateSpot(spotRequestDto));
@@ -80,7 +81,8 @@ public class SpotController {
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<SpotResponseDto> spotUpdate(@RequestPart(value = "data")
-                                               SpotUpdatedImagesDto spotRequestDto,
+            @Valid SpotUpdatedImagesDto spotRequestDto,
+                                           @ImageSizeValid
                                            @RequestPart(value = "images", required = false)
                                            List<MultipartFile> images) {
 

--- a/src/main/java/trendravel/photoravel_be/domain/spot/controller/SpotController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/controller/SpotController.java
@@ -28,7 +28,7 @@ public class SpotController {
 
     @Schema(description = "스팟 CREATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PostMapping(value = "/spot/create")
+    @PostMapping(value = "/private/spot/create")
     public Api<SpotResponseDto> spotCreate(@RequestBody
                                        SpotRequestDto spotRequestDto){
 
@@ -37,7 +37,7 @@ public class SpotController {
 
     @Schema(description = "스팟 CREATE 요청/응답 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PostMapping(value = "/spot/create",
+    @PostMapping(value = "/private/spot/create",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<SpotResponseDto> spotCreate(@RequestPart(value = "data")
@@ -67,7 +67,7 @@ public class SpotController {
 
     @Schema(description = "스팟 UPDATE 요청/응답 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PatchMapping(value = "/spot/update")
+    @PatchMapping(value = "/private/spot/update")
     public Api<SpotResponseDto> spotUpdate(@RequestBody
                                        SpotRequestDto spotRequestDto) {
 
@@ -76,7 +76,7 @@ public class SpotController {
 
     @Schema(description = "스팟 UPDATE 요청/응답 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PatchMapping(value = "/spot/update",
+    @PatchMapping(value = "/private/spot/update",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<SpotResponseDto> spotUpdate(@RequestPart(value = "data")
@@ -88,7 +88,7 @@ public class SpotController {
     }
 
     @Schema(description = "스팟 DELETE 요청")
-    @DeleteMapping("/spot/{spotId}/delete")
+    @DeleteMapping("/private/spot/{spotId}/delete")
     public Result spotDelete(@PathVariable("spotId") Long spotId) {
         spotService.deleteSpot(spotId);
 

--- a/src/main/java/trendravel/photoravel_be/domain/spot/dto/request/SpotRequestDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/dto/request/SpotRequestDto.java
@@ -1,7 +1,10 @@
 package trendravel.photoravel_be.domain.spot.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.MediaType;
 
 
@@ -13,12 +16,17 @@ public class SpotRequestDto {
     @Schema(description = "스팟 ID")
     private Long spotId;
     @Schema(description = "스팟 제목")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 50, message="최대 길이는 50자 입니다.")
     private String title;
     @Schema(description = "스팟 내용")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
     private String description;
     @Schema(description = "리뷰 위도")
+    @NotNull(message = "필수 입력사항입니다.")
     private double latitude;
     @Schema(description = "리뷰 경도")
+    @NotNull(message = "필수 입력사항입니다.")
     private double longitude;
     @Schema(description = "장소 ID")
     private Long locationId;

--- a/src/main/java/trendravel/photoravel_be/domain/spot/dto/request/SpotUpdatedImagesDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/dto/request/SpotUpdatedImagesDto.java
@@ -1,7 +1,10 @@
 package trendravel.photoravel_be.domain.spot.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.http.MediaType;
 
 import java.util.List;
@@ -15,12 +18,17 @@ public class SpotUpdatedImagesDto {
     @Schema(description = "스팟 ID")
     private Long spotId;
     @Schema(description = "스팟 제목")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
+    @Length(max = 50, message="최대 길이는 50자 입니다.")
     private String title;
     @Schema(description = "스팟 내용")
+    @NotBlank(message = "공백/null 입력은 미허용됩니다.")
     private String description;
     @Schema(description = "리뷰 위도")
+    @NotNull(message = "필수 입력사항입니다.")
     private double latitude;
     @Schema(description = "리뷰 경도")
+    @NotNull(message = "필수 입력사항입니다.")
     private double longitude;
     @Schema(description = "장소 ID")
     private Long locationId;

--- a/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotMultiReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotMultiReadResponseDto.java
@@ -35,10 +35,6 @@ public class SpotMultiReadResponseDto {
     //유저 객체 추가 필요
 
 
-    // 프론트엔드측과 의논 후 추가 여부 결정
-    //private List<RecentReviewsDto> recentReviewDtos;
-
-
     // 유저 객체 전달 필요
     @Schema(description = "스팟 생성일")
     private LocalDateTime createAt;

--- a/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotSingleReadResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/dto/response/SpotSingleReadResponseDto.java
@@ -33,7 +33,10 @@ public class SpotSingleReadResponseDto {
     private int views;
 
     @Schema(description = "단일 스팟의 모든 리뷰 평균 평점")
-    private String ratingAvg;
+    private Double ratingAvg;
+
+    @Schema(description = "장소 리뷰 수")
+    private Integer reviewCounts;
 
     //유저 객체 추가 필요
 

--- a/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
@@ -52,7 +52,8 @@ public class SpotService {
                 .build();
         spot.setLocation(location);
         spotRepository.save(spot);
-        spot.createSpotImage(imageService.uploadImages(images));
+        spot.createSpotImage(imageService.uploadImageFacade(images));
+        imageService.uploadImages(images);
 
         return SpotResponseDto
                 .builder()
@@ -162,7 +163,7 @@ public class SpotService {
                 spotRequestDto.getSpotId())
                 .orElseThrow(() -> new ApiException(SpotErrorCode.SPOT_NOT_FOUND));
 
-        spot.updateSpot(spotRequestDto, imageService.updateImages(
+        spot.updateSpot(spotRequestDto, imageService.updateImageFacade(
                 images, spotRequestDto.getDeleteImages()));
 
         return SpotResponseDto
@@ -205,7 +206,7 @@ public class SpotService {
         Spot findSpot = spotRepository.findById(id)
                 .orElseThrow(() -> new ApiException(SpotErrorCode.SPOT_NOT_FOUND));
         spotRepository.deleteById(findSpot.getId());
-        imageService.deleteAllImages(findSpot.getImages());
+        imageService.deleteAllImagesFacade(findSpot.getImages());
     }
 
 

--- a/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
@@ -121,8 +121,10 @@ public class SpotService {
                 .latitude(spot.getLatitude())
                 .longitude(spot.getLongitude())
                 .images(spot.getImages())
-                .ratingAvg(String.format("%.2f", ratingAverage(spot.getReviews())))
+                .ratingAvg(Double.parseDouble
+                        (String.format("%.2f", ratingAverage(spot.getReviews()))))
                 .recentReviewDtos(reviews)
+                .reviewCounts(spot.getReviews().size() < 100 ? spot.getReviews().size(): 99)
                 .build();
     }
 

--- a/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
@@ -1,10 +1,9 @@
 package trendravel.photoravel_be.domain.spot.service;
 
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import trendravel.photoravel_be.commom.error.ErrorCode;
 import trendravel.photoravel_be.commom.error.LocationErrorCode;
 import trendravel.photoravel_be.commom.error.SpotErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
@@ -35,6 +34,7 @@ public class SpotService {
     private final LocationRepository locationRepository;
     private final ImageService imageService;
 
+    @Transactional
     public SpotResponseDto createSpot(
             SpotRequestDto spotRequestDto, List<MultipartFile> images) {
 
@@ -67,6 +67,7 @@ public class SpotService {
                 .build();
     }
 
+    @Transactional
     public SpotResponseDto createSpot(
             SpotRequestDto spotRequestDto) {
         Location location = locationRepository.findById(spotRequestDto.
@@ -97,16 +98,16 @@ public class SpotService {
     }
 
 
-    @Transactional
+    @Transactional(readOnly = true)
     public SpotSingleReadResponseDto readSingleSpot(Long locationId, Long spotId) {
         List<Spot> spots = locationRepository.findById(locationId)
                 .map(Location::getSpot)
                 .orElseThrow(() -> new ApiException(LocationErrorCode.LOCATION_NOT_FOUND));
 
-
         Spot spot = spots.stream().
                 filter(s -> s.getId().equals(spotId)).findFirst()
                 .orElseThrow(() -> new ApiException(SpotErrorCode.SPOT_NOT_FOUND));
+        spot.increaseViews();
 
         List<RecentReviewsDto> reviews = spotRepository.recentReviews(spot.getId());
 
@@ -125,7 +126,7 @@ public class SpotService {
                 .build();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<SpotMultiReadResponseDto> readMultiSpot(Long locationId) {
         List<Spot> spots = locationRepository.findById(locationId)
                 .map(Location::getSpot)

--- a/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
@@ -8,6 +8,7 @@ import trendravel.photoravel_be.commom.error.LocationErrorCode;
 import trendravel.photoravel_be.commom.error.SpotErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
 import trendravel.photoravel_be.commom.image.service.ImageService;
+import trendravel.photoravel_be.commom.image.service.ImageServiceFacade;
 import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.db.review.Review;
 import trendravel.photoravel_be.domain.review.dto.response.RecentReviewsDto;
@@ -32,7 +33,7 @@ public class SpotService {
 
     private final SpotRepository spotRepository;
     private final LocationRepository locationRepository;
-    private final ImageService imageService;
+    private final ImageServiceFacade imageServiceFacade;
 
     @Transactional
     public SpotResponseDto createSpot(
@@ -48,12 +49,11 @@ public class SpotService {
                 .title(spotRequestDto.getTitle())
                 .latitude(spotRequestDto.getLatitude())
                 .longitude(spotRequestDto.getLongitude())
-                .location(location)
+                .description(spotRequestDto.getDescription())
+                .images(imageServiceFacade.uploadImageFacade(images))
                 .build();
         spot.setLocation(location);
         spotRepository.save(spot);
-        spot.createSpotImage(imageService.uploadImageFacade(images));
-        imageService.uploadImages(images);
 
         return SpotResponseDto
                 .builder()
@@ -163,7 +163,7 @@ public class SpotService {
                 spotRequestDto.getSpotId())
                 .orElseThrow(() -> new ApiException(SpotErrorCode.SPOT_NOT_FOUND));
 
-        spot.updateSpot(spotRequestDto, imageService.updateImageFacade(
+        spot.updateSpot(spotRequestDto, imageServiceFacade.updateImageFacade(
                 images, spotRequestDto.getDeleteImages()));
 
         return SpotResponseDto
@@ -206,7 +206,7 @@ public class SpotService {
         Spot findSpot = spotRepository.findById(id)
                 .orElseThrow(() -> new ApiException(SpotErrorCode.SPOT_NOT_FOUND));
         spotRepository.deleteById(findSpot.getId());
-        imageService.deleteAllImagesFacade(findSpot.getImages());
+        imageServiceFacade.deleteAllImagesFacade(findSpot.getImages());
     }
 
 

--- a/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/spot/service/SpotService.java
@@ -48,11 +48,11 @@ public class SpotService {
                 .title(spotRequestDto.getTitle())
                 .latitude(spotRequestDto.getLatitude())
                 .longitude(spotRequestDto.getLongitude())
-                .images(imageService.uploadImages(images))
                 .location(location)
                 .build();
         spot.setLocation(location);
         spotRepository.save(spot);
+        spot.createSpotImage(imageService.uploadImages(images));
 
         return SpotResponseDto
                 .builder()

--- a/src/test/java/trendravel/photoravel_be/commom/image/service/ImageServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/commom/image/service/ImageServiceTest.java
@@ -45,7 +45,7 @@ class ImageServiceTest {
     void imageUploadTest() {
         List<MultipartFile> list = new ArrayList<>();
         list.add(mockMultipartFile);
-        List<String> urls = imageService.uploadImages(list);
+        List<String> urls = imageService.getImagesName(list);
         assertThat(urls.get(0).substring(urls.get(0).lastIndexOf(".")+1)).isEqualTo("png");
         assertThat(urls.get(0).substring(urls.get(0).lastIndexOf("/")+1,
                 urls.get(0).lastIndexOf("_"))).isEqualTo(
@@ -60,7 +60,7 @@ class ImageServiceTest {
     void imageUpdateTest(){
         List<MultipartFile> list = new ArrayList<>();
         list.add(mockMultipartFile);
-        List<String> urls = imageService.uploadImages(list);
+        List<String> urls = imageService.getImagesName(list);
 
         list.clear();
         list.add(mockMultipartFile2);

--- a/src/test/java/trendravel/photoravel_be/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/domain/review/service/ReviewServiceTest.java
@@ -12,6 +12,7 @@ import trendravel.photoravel_be.commom.error.ReviewErrorCode;
 import trendravel.photoravel_be.commom.error.SpotErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
 import trendravel.photoravel_be.commom.image.service.ImageService;
+import trendravel.photoravel_be.commom.image.service.ImageServiceFacade;
 import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.db.respository.location.LocationRepository;
 import trendravel.photoravel_be.db.respository.review.ReviewRepository;
@@ -44,7 +45,7 @@ class ReviewServiceTest {
     ReviewService reviewService;
 
     @MockBean
-    ImageService imageService;
+    ImageServiceFacade imageService;
 
     ReviewRequestDto locationReviewRequestDto = new ReviewRequestDto();
     ReviewRequestDto spotReviewRequestDto = new ReviewRequestDto();

--- a/src/test/java/trendravel/photoravel_be/repository/LocationRepositoryTest.java
+++ b/src/test/java/trendravel/photoravel_be/repository/LocationRepositoryTest.java
@@ -3,6 +3,7 @@ package trendravel.photoravel_be.repository;
 
 
 import jakarta.transaction.Transactional;
+import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,9 +20,11 @@ import trendravel.photoravel_be.db.review.enums.ReviewTypes;
 import trendravel.photoravel_be.db.spot.Spot;
 import trendravel.photoravel_be.domain.location.dto.request.LocationNowPositionDto;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 @SpringBootTest
@@ -146,6 +149,36 @@ class LocationRepositoryTest {
         assertThat(locations.get(0).getViews()).isEqualTo(location.getViews());
         assertThat(locations.get(0).getLatitude()).isEqualTo(location.getLatitude());
         assertThat(locations.get(0).getLongitude()).isEqualTo(location.getLongitude());
+    }
+
+
+    @Test
+    @DisplayName("공백/null 입력 미허용 검증 예외를 잘 터트리는지 테스트")
+    void validateIsBlankTest(){
+        Location nullLocation = Location.builder()
+                .id(1L)
+                .address(" ")
+                .description(" ")
+                .name(" ")
+                .build();
+        assertThatThrownBy(() -> locationRepository.save(nullLocation))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("공백/null 입력은 미허용됩니다.");
+    }
+
+
+    @Test
+    @DisplayName("제한된 길이 이상의 입력값이 들어왔을 때, 검증 예외를 잘 터트리는지 테스트")
+    void validateLengthTest(){
+        Location longLocation = Location.builder()
+                .id(1L)
+                .address("아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아")
+                .name("아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아아")
+                .build();
+
+        assertThatThrownBy(() -> locationRepository.save(longLocation))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("최대 길이는 50글자입니다.");
     }
 
 

--- a/src/test/java/trendravel/photoravel_be/repository/ReviewRepositoryTest.java
+++ b/src/test/java/trendravel/photoravel_be/repository/ReviewRepositoryTest.java
@@ -1,10 +1,12 @@
 package trendravel.photoravel_be.repository;
 
+import jakarta.transaction.Transactional;
+import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import trendravel.photoravel_be.db.respository.location.LocationRepository;
 import trendravel.photoravel_be.db.respository.review.ReviewRepository;
 import trendravel.photoravel_be.db.respository.spot.SpotRepository;
@@ -17,8 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DataJpaTest
+@SpringBootTest
 class ReviewRepositoryTest {
 
     Location location;
@@ -79,6 +82,7 @@ class ReviewRepositoryTest {
 
     @Test
     @DisplayName("reviewRepository에 잘 저장되는지 테스트")
+    @Transactional
     void saveRepository(){
         Review findSpotReview = reviewRepository.save(spotReview);
         Review findLocationReview = reviewRepository.save(locationReview);
@@ -99,6 +103,78 @@ class ReviewRepositoryTest {
         assertThat(findLocationReview.getLocationReview()).isEqualTo(locationReview.getLocationReview());
     }
 
+    @Test
+    @DisplayName("공백/null 입력 미허용 검증 예외를 잘 터트리는지 테스트")
+    @Transactional
+    void validateIsBlankTest(){
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 501; i++) {
+            sb.append(i);
+        }
 
+        Review nullreview = Review.builder()
+                .id(1L)
+                .reviewType(ReviewTypes.valueOf("LOCATION"))
+                .content(" ")
+                .build();
+        assertThatThrownBy(() -> reviewRepository.save(nullreview))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("공백/null 입력은 미허용됩니다.");
+    }
+
+
+    @Test
+    @DisplayName("제한된 길이 이상의 입력값이 들어왔을 때, 검증 예외를 잘 터트리는지 테스트")
+    @Transactional
+    void validateLengthTest(){
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 501; i++) {
+            sb.append(i);
+        }
+
+        Review longReview = Review.builder()
+                .id(1L)
+                .reviewType(ReviewTypes.valueOf("LOCATION"))
+                .content(sb.toString())
+                .rating(1.0)
+                .build();
+
+        assertThatThrownBy(() -> reviewRepository.save(longReview))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("최대 길이는 500자 입니다.");
+    }
+
+
+    @Test
+    @DisplayName("제한된 길이 이상의 입력값이 들어왔을 때, 검증 예외를 잘 터트리는지 테스트")
+    @Transactional
+    void validateRatingRangeTest(){
+
+        Review minRatingReview = Review.builder()
+                .id(1L)
+                .reviewType(ReviewTypes.valueOf("LOCATION"))
+                .content("굿")
+                .rating(0.5)
+                .build();
+
+        Review maxRatingReview = Review.builder()
+                .id(1L)
+                .reviewType(ReviewTypes.valueOf("LOCATION"))
+                .content("굿")
+                .rating(5.5)
+                .build();
+
+
+
+        assertThatThrownBy(() -> reviewRepository.save(minRatingReview))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("최소 허용 별점은 1.0입니다.");
+
+
+        assertThatThrownBy(() -> reviewRepository.save(maxRatingReview))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("최대 허용 별점은 5.0입니다.");
+
+    }
 
 }

--- a/src/test/java/trendravel/photoravel_be/repository/SpotRepositoryTest.java
+++ b/src/test/java/trendravel/photoravel_be/repository/SpotRepositoryTest.java
@@ -1,10 +1,12 @@
 package trendravel.photoravel_be.repository;
 
+import jakarta.transaction.Transactional;
+import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import trendravel.photoravel_be.db.respository.location.LocationRepository;
 import trendravel.photoravel_be.db.respository.review.ReviewRepository;
 import trendravel.photoravel_be.db.respository.spot.SpotRepository;
@@ -17,8 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DataJpaTest
+@SpringBootTest
 public class SpotRepositoryTest {
 
     Location location;
@@ -68,6 +71,7 @@ public class SpotRepositoryTest {
 
     @Test
     @DisplayName("spotRepository에 잘 저장되는지 테스트")
+    @Transactional
     void saveRepository(){
         spotRepository.save(spot);
         Spot findSpot = spotRepository.findById(spot.getId()).get();
@@ -84,6 +88,7 @@ public class SpotRepositoryTest {
 
     @Test
     @DisplayName("Spot-Review 연관관계 연결이 잘 되는지 확인")
+    @Transactional
     void correlatedReviewTest(){
         spotRepository.save(spot);
         spotReview.setSpotReview(spot);
@@ -101,6 +106,22 @@ public class SpotRepositoryTest {
 
         assertThat(findReview.getSpotReview().getId()).isEqualTo(spot.getId());
     }
+
+
+    @Test
+    @DisplayName("공백/null 입력 미허용 검증 예외를 잘 터트리는지 테스트")
+    @Transactional
+    void validateIsBlankTest(){
+        Spot nullSpot = Spot.builder()
+                .id(1L)
+                .title(" ")
+                .description(" ")
+                .build();
+        assertThatThrownBy(() -> spotRepository.save(nullSpot))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("공백/null 입력은 미허용됩니다.");
+    }
+
 
 
 }

--- a/src/test/java/trendravel/photoravel_be/service/LocationServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/service/LocationServiceTest.java
@@ -226,9 +226,9 @@ class LocationServiceTest {
         assertThat(locationSingleReadResponseDto.getAddress())
                 .isEqualTo(findLocation.getAddress());
         assertThat(locationSingleReadResponseDto.getRatingAvg())
-                .isEqualTo(String.format("%.2f",
+                .isEqualTo(Double.parseDouble(String.format("%.2f",
                         (review4.getRating() + review2.getRating()
-                                + review3.getRating() + review1.getRating()) / 4));
+                                + review3.getRating() + review1.getRating()) / 4)));
         assertThat(locationSingleReadResponseDto.getViews()).isEqualTo(1);
         assertThat(findRecentReviews).extracting("rating")
                 .containsExactlyInAnyOrder(review4.getRating(),
@@ -315,6 +315,31 @@ class LocationServiceTest {
                 .hasMessageContaining(LocationErrorCode.LOCATION_NOT_FOUND.getErrorDescription());
     }
 
+    @DisplayName("LOCATION의 리뷰 수가 100개 이상일 때, 99개로 변경하여 잘 보내는지 테스트")
+    @Test
+    @Transactional
+    @Order(9)
+    void locationReviewCountsMoreThanOneHundredTest(){
+
+        for (int i = 0; i < 1000; i++) {
+            review1.setLocationReview(location);
+            reviewRepository.save(review1);
+        }
+        Long id = locationRepository.save(location).getId();
+
+        assertThat(locationService.readSingleLocation(id).getReviewCounts()).isEqualTo(99);
+    }
+
+    @DisplayName("LOCATION의 리뷰 수가 100개 이하일 때, 그 개수를 그대로 READ하는지 테스트")
+    @Test
+    @Transactional
+    @Order(10)
+    void locationReviewCountsLessThanOneHundredTest(){
+        Long id = locationRepository.save(location).getId();
+
+        assertThat(locationService.readSingleLocation(id).getReviewCounts())
+                .isEqualTo(location.getReview().size());
+    }
 
 
 }

--- a/src/test/java/trendravel/photoravel_be/service/LocationServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/service/LocationServiceTest.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import trendravel.photoravel_be.commom.error.LocationErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
-import trendravel.photoravel_be.commom.image.service.ImageService;
+import trendravel.photoravel_be.commom.image.service.ImageServiceFacade;
 import trendravel.photoravel_be.db.location.Location;
 import trendravel.photoravel_be.db.respository.review.ReviewRepository;
 import trendravel.photoravel_be.db.review.Review;
@@ -44,7 +44,7 @@ class LocationServiceTest {
     @MockBean
     LocationService locationService;
     @MockBean
-    ImageService imageService;
+    ImageServiceFacade imageService;
 
     LocationRequestDto locationRequestDto;
     Location location;

--- a/src/test/java/trendravel/photoravel_be/service/SpotServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/service/SpotServiceTest.java
@@ -71,6 +71,7 @@ class SpotServiceTest {
                 .latitude(35.24)
                 .longitude(46.61)
                 .address("아산시 신창면 순천향로46")
+                .description("순천향대학교입니다.")
                 .point(new GeometryFactory().createPoint(
                         new Coordinate(35.24
                                 , 46.61)))
@@ -229,7 +230,7 @@ class SpotServiceTest {
                 .isEqualTo(String.format("%.2f",
                         (review4.getRating() + review2.getRating()
                                 + review3.getRating() + review1.getRating()) / 4));
-        assertThat(spotSingleReadResponseDto.getViews()).isEqualTo(0);
+        assertThat(spotSingleReadResponseDto.getViews()).isEqualTo(1);
         assertThat(findRecentReviews.size()).isGreaterThan(1);
         assertThat(findRecentReviews).extracting("rating")
                 .containsExactlyInAnyOrder(review4.getRating(),

--- a/src/test/java/trendravel/photoravel_be/service/SpotServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/service/SpotServiceTest.java
@@ -227,9 +227,9 @@ class SpotServiceTest {
         assertThat(spotSingleReadResponseDto.getTitle())
                 .isEqualTo(findSpot.getTitle());
         assertThat(spotSingleReadResponseDto.getRatingAvg())
-                .isEqualTo(String.format("%.2f",
+                .isEqualTo(Double.parseDouble(String.format("%.2f",
                         (review4.getRating() + review2.getRating()
-                                + review3.getRating() + review1.getRating()) / 4));
+                                + review3.getRating() + review1.getRating()) / 4)));
         assertThat(spotSingleReadResponseDto.getViews()).isEqualTo(1);
         assertThat(findRecentReviews.size()).isGreaterThan(1);
         assertThat(findRecentReviews).extracting("rating")
@@ -289,6 +289,36 @@ class SpotServiceTest {
         assertThatThrownBy(() -> spotService.deleteSpot(100L))
                 .isInstanceOf(ApiException.class)
                 .hasMessageContaining(SpotErrorCode.SPOT_NOT_FOUND.getErrorDescription());
+    }
+
+    @DisplayName("SPOT의 리뷰 수가 100개 이상일 때, 99개로 변경하여 잘 보내는지 테스트")
+    @Test
+    @Transactional
+    @Order(10)
+    void locationReviewCountsMoreThanOneHundredTest(){
+        Long locationId = locationRepository.save(location).getId();
+        for (int i = 0; i < 1000; i++) {
+            review1.setSpotReview(spot);
+            reviewRepository.save(review1);
+        }
+        spot.setLocation(location);
+        Long id = spotRepository.save(spot).getId();
+
+        assertThat(spotService.readSingleSpot(locationId, id).getReviewCounts())
+                .isEqualTo(99);
+    }
+
+    @DisplayName("SPOT의 리뷰 수가 100개 이하일 때, 그 개수를 그대로 READ하는지 테스트")
+    @Test
+    @Transactional
+    @Order(11)
+    void locationReviewCountsLessThanOneHundredTest(){
+        Long locationId = locationRepository.save(location).getId();
+        spot.setLocation(location);
+        Long id = spotRepository.save(spot).getId();
+
+        assertThat(spotService.readSingleSpot(locationId, id).getReviewCounts())
+                .isEqualTo(location.getReview().size());
     }
 
 


### PR DESCRIPTION
# 기존 문제점
- ImageService에서는 Facade 메소드와 S3에 직접 접근할 수 있는 메소드가 존재함
- private으로 바꾸고 싶으나, event가 접근하기 위해서는 public 접근이 필요한 상황

# 문제 해결 리팩토링
- Facade 클래스를 새로 만들어서 ImageService에 있는 Facade 코드들을 뽑아옴
- 기존 Service들은 이제 ImageService가 아닌 ImageServiceFacade 기능을 이용해, 이미지 서비스 기능 사용
- S3 이미지 저장/삭제 관련 이벤트 등록과 ImagePath 리턴을 함께 처리하도록 하여, 코드 간소화 됨

# 파사드 패턴
![image](https://github.com/user-attachments/assets/957db4f4-eb1e-4799-8be8-dcb5ea25bca0)
각 도메인 Service는 파사드 클래스 사용만 할줄 알면 Image Service와 관련된 모든 작업을 할 수 있게 됨


# 다음 목표
- Enum Type Validator 구현
- querydsl에서 발생한 N+1 문제 해결과 동적쿼리로의 변환 리팩토링
- 중복 코드 개선 및 디자인 패턴 적용 리팩토링 고민
