### PR TITLE
[Feat] 매칭 로직 구현

### DIFF
--- a/src/main/java/trendravel/photoravel_be/commom/error/MatchingErrorCode.java
+++ b/src/main/java/trendravel/photoravel_be/commom/error/MatchingErrorCode.java
@@ -1,0 +1,17 @@
+package trendravel.photoravel_be.commom.error;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum MatchingErrorCode implements ErrorCodeIfs{
+    
+    MATCHING_STATUS_INVALID(400, "매칭 상태가 올바르지 않습니다"),
+    MEMBER_ALREADY_HAS_MATCHING(400 , "멤버는 이미 매칭이 존재합니다");
+    
+
+    private final Integer httpStatusCode;
+    private final String errorDescription;
+}

--- a/src/main/java/trendravel/photoravel_be/db/match/Matching.java
+++ b/src/main/java/trendravel/photoravel_be/db/match/Matching.java
@@ -30,5 +30,8 @@ public class Matching {
 
     private String photographerId;
     
+    public void updateStatus(MatchingStatus status) {
+        this.status = status;
+    }
     
 }

--- a/src/main/java/trendravel/photoravel_be/db/match/Matching.java
+++ b/src/main/java/trendravel/photoravel_be/db/match/Matching.java
@@ -26,13 +26,9 @@ public class Matching {
     private MatchingStatus status;
     
     
-    @OneToOne
-    @JoinColumn(name = "member_id", unique = true)
-    private MemberEntity member;
-    
-    @ManyToOne
-    @JoinColumn(name = "photographer_id")
-    private Photographer photographer;
+    private String memberId;
+
+    private String photographerId;
     
     
 }

--- a/src/main/java/trendravel/photoravel_be/db/match/Matching.java
+++ b/src/main/java/trendravel/photoravel_be/db/match/Matching.java
@@ -1,0 +1,38 @@
+package trendravel.photoravel_be.db.match;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import trendravel.photoravel_be.db.match.enums.MatchingStatus;
+import trendravel.photoravel_be.db.member.MemberEntity;
+import trendravel.photoravel_be.db.photographer.Photographer;
+
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "MATCHING")
+public class Matching {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Enumerated(EnumType.STRING)
+    private MatchingStatus status;
+    
+    
+    @OneToOne
+    @JoinColumn(name = "member_id", unique = true)
+    private MemberEntity member;
+    
+    @ManyToOne
+    @JoinColumn(name = "photographer_id")
+    private Photographer photographer;
+    
+    
+}

--- a/src/main/java/trendravel/photoravel_be/db/match/enums/MatchingStatus.java
+++ b/src/main/java/trendravel/photoravel_be/db/match/enums/MatchingStatus.java
@@ -4,5 +4,6 @@ public enum MatchingStatus {
     PENDING, // 매칭 신청 중
     ACCEPTED, // 매칭 중
     REJECTED, // 매칭 거절 됨
-    COMPLETED // 매칭 완료 상태
+    COMPLETED, // 매칭 완료 상태
+    CANCELED // 매칭 취소
 }

--- a/src/main/java/trendravel/photoravel_be/db/match/enums/MatchingStatus.java
+++ b/src/main/java/trendravel/photoravel_be/db/match/enums/MatchingStatus.java
@@ -1,0 +1,8 @@
+package trendravel.photoravel_be.db.match.enums;
+
+public enum MatchingStatus {
+    PENDING, // 매칭 신청 중
+    ACCEPTED, // 매칭 중
+    REJECTED, // 매칭 거절 됨
+    COMPLETED // 매칭 완료 상태
+}

--- a/src/main/java/trendravel/photoravel_be/db/member/MemberEntity.java
+++ b/src/main/java/trendravel/photoravel_be/db/member/MemberEntity.java
@@ -3,6 +3,7 @@ package trendravel.photoravel_be.db.member;
 import jakarta.persistence.*;
 import lombok.*;
 import trendravel.photoravel_be.db.BaseEntity;
+import trendravel.photoravel_be.db.match.Matching;
 
 @Entity
 @Table(name = "member")
@@ -38,5 +39,7 @@ public class MemberEntity extends BaseEntity {
         this.email = email;
         this.profileImg = profileImg;
     }
-
+    
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Matching matching;
 }

--- a/src/main/java/trendravel/photoravel_be/db/member/MemberEntity.java
+++ b/src/main/java/trendravel/photoravel_be/db/member/MemberEntity.java
@@ -39,7 +39,5 @@ public class MemberEntity extends BaseEntity {
         this.email = email;
         this.profileImg = profileImg;
     }
-    
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Matching matching;
+
 }

--- a/src/main/java/trendravel/photoravel_be/db/photographer/Photographer.java
+++ b/src/main/java/trendravel/photoravel_be/db/photographer/Photographer.java
@@ -5,12 +5,14 @@ import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import trendravel.photoravel_be.db.BaseEntity;
 import trendravel.photoravel_be.db.enums.Region;
+import trendravel.photoravel_be.db.match.Matching;
 import trendravel.photoravel_be.db.review.Review;
-import trendravel.photoravel_be.domain.photographer.dto.request.PhotographerRequestDto;
 import trendravel.photoravel_be.domain.photographer.dto.request.PhotographerUpdateDto;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -67,5 +69,9 @@ public class Photographer extends BaseEntity {
     @OneToMany(mappedBy = "photographerReview")
     @Builder.Default
     private List<Review> reviews = new ArrayList<>();
+    
+    @OneToMany(mappedBy = "photographer", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Matching> matchings = new HashSet<>();
+    
     
 }

--- a/src/main/java/trendravel/photoravel_be/db/photographer/Photographer.java
+++ b/src/main/java/trendravel/photoravel_be/db/photographer/Photographer.java
@@ -45,6 +45,9 @@ public class Photographer extends BaseEntity {
     @Column(nullable = false)
     private String profileImg;
     
+    @Column(nullable = false)
+    private Integer careerYear;
+    
     //images 타입에 대해 수정 필요 imageService 단에서 하나의 이미지를 처리하는 메서드 필요
     public void updatePhotographer(PhotographerUpdateDto photographerUpdateDto, List<String> images) {
         this.password = photographerUpdateDto.getPassword();

--- a/src/main/java/trendravel/photoravel_be/db/photographer/Photographer.java
+++ b/src/main/java/trendravel/photoravel_be/db/photographer/Photographer.java
@@ -70,8 +70,5 @@ public class Photographer extends BaseEntity {
     @Builder.Default
     private List<Review> reviews = new ArrayList<>();
     
-    @OneToMany(mappedBy = "photographer", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<Matching> matchings = new HashSet<>();
-    
     
 }

--- a/src/main/java/trendravel/photoravel_be/db/respository/matching/MatchingRepository.java
+++ b/src/main/java/trendravel/photoravel_be/db/respository/matching/MatchingRepository.java
@@ -3,8 +3,18 @@ package trendravel.photoravel_be.db.respository.matching;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import trendravel.photoravel_be.db.match.Matching;
+import trendravel.photoravel_be.db.match.enums.MatchingStatus;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
+    
+    List<Matching> findByMemberId(String memberId);
+    boolean existsByMemberIdAndStatusIn(String memberId, List<MatchingStatus> pending);
+    Optional<Matching> findByMemberIdAndStatus(String memberId, MatchingStatus matchingStatus);
+    
+    
     
 }

--- a/src/main/java/trendravel/photoravel_be/db/respository/matching/MatchingRepository.java
+++ b/src/main/java/trendravel/photoravel_be/db/respository/matching/MatchingRepository.java
@@ -1,0 +1,10 @@
+package trendravel.photoravel_be.db.respository.matching;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import trendravel.photoravel_be.db.match.Matching;
+
+@Repository
+public interface MatchingRepository extends JpaRepository<Long, Matching> {
+    
+}

--- a/src/main/java/trendravel/photoravel_be/db/respository/matching/MatchingRepository.java
+++ b/src/main/java/trendravel/photoravel_be/db/respository/matching/MatchingRepository.java
@@ -5,6 +5,6 @@ import org.springframework.stereotype.Repository;
 import trendravel.photoravel_be.db.match.Matching;
 
 @Repository
-public interface MatchingRepository extends JpaRepository<Long, Matching> {
+public interface MatchingRepository extends JpaRepository<Matching, Long> {
     
 }

--- a/src/main/java/trendravel/photoravel_be/db/respository/member/MemberRepository.java
+++ b/src/main/java/trendravel/photoravel_be/db/respository/member/MemberRepository.java
@@ -11,6 +11,8 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     Optional<MemberEntity> findByMemberId(String memberId);
     Optional<MemberEntity> findByNickname(String nickname);
     void deleteByMemberId(String memberId);
+    
+    boolean existsByMemberId(String memberId);
 }
 
 

--- a/src/main/java/trendravel/photoravel_be/db/respository/photographer/PhotographerRepository.java
+++ b/src/main/java/trendravel/photoravel_be/db/respository/photographer/PhotographerRepository.java
@@ -17,6 +17,8 @@ public interface PhotographerRepository extends JpaRepository<Photographer, Long
     
     void deleteByAccountId(String accountId);
     
+    boolean existsByAccountId(String photographerId);
+    
     //List<RecentReviewsDto> recentReviews(Long id);
     
 }

--- a/src/main/java/trendravel/photoravel_be/domain/matching/controller/MatchingController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/matching/controller/MatchingController.java
@@ -28,12 +28,20 @@ public class MatchingController {
         return Result.CREATED();
     }
     
-    @Schema(description = "매칭 목록 조회",
+    @Schema(description = "유저의 매칭 목록 조회",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @GetMapping("/{memberId}")
-    Api<List<MatchingResponseDto>> getMatching(@PathVariable String memberId) {
+    @GetMapping("/user/{memberId}")
+    Api<List<MatchingResponseDto>> getMemberMatching(@PathVariable String memberId) {
         
         return Api.OK(matchingService.getMatchingList(memberId));
+    }
+    
+    @Schema(description = "사진작가의 매칭 목록 조회",
+            contentEncoding = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping("/photographer/{accountId}")
+    Api<List<MatchingResponseDto>> getPhotographerMatching(@PathVariable String accountId) {
+        
+        return Api.OK(matchingService.getMatchingList(accountId));
     }
 
     @Schema(description = "매칭 취소",

--- a/src/main/java/trendravel/photoravel_be/domain/matching/controller/MatchingController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/matching/controller/MatchingController.java
@@ -1,0 +1,13 @@
+package trendravel.photoravel_be.domain.matching.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/matching")
+@RequiredArgsConstructor
+public class MatchingController {
+    
+    
+}

--- a/src/main/java/trendravel/photoravel_be/domain/matching/controller/MatchingController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/matching/controller/MatchingController.java
@@ -33,7 +33,7 @@ public class MatchingController {
     @GetMapping("/{memberId}")
     Api<List<MatchingResponseDto>> getMatching(@PathVariable String memberId) {
         
-        return Api.CREATED(matchingService.getMatchingList(memberId));
+        return Api.OK(matchingService.getMatchingList(memberId));
     }
 
     @Schema(description = "매칭 취소",
@@ -53,7 +53,7 @@ public class MatchingController {
         
         matchingService.accept(matchingRequestDto);
         
-        return Result.CREATED();
+        return Result.OK();
     }
     
     @Schema(description = "매칭 거절",
@@ -63,7 +63,7 @@ public class MatchingController {
         
         matchingService.reject(matchingRequestDto);
         
-        return Result.CREATED();
+        return Result.OK();
     }
     
     @Schema(description = "매칭 종료",
@@ -73,7 +73,7 @@ public class MatchingController {
         
         matchingService.complete(matchingRequestDto);
                 
-        return Result.CREATED();
+        return Result.OK();
     }
     
     

--- a/src/main/java/trendravel/photoravel_be/domain/matching/controller/MatchingController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/matching/controller/MatchingController.java
@@ -1,13 +1,80 @@
 package trendravel.photoravel_be.domain.matching.controller;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import trendravel.photoravel_be.commom.response.Api;
+import trendravel.photoravel_be.commom.response.Result;
+import trendravel.photoravel_be.domain.matching.dto.request.MatchingRequestDto;
+import trendravel.photoravel_be.domain.matching.dto.response.MatchingResponseDto;
+import trendravel.photoravel_be.domain.matching.service.MatchingService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/matching")
 @RequiredArgsConstructor
 public class MatchingController {
+    
+    private final MatchingService matchingService;
+    
+    @Schema(description = "매칭 PENDING (CREATE) 요청",
+            contentEncoding = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping("/pending")
+    Result pendingMatching(@RequestBody MatchingRequestDto matchingRequestDto) {
+        
+        matchingService.pendingMatching(matchingRequestDto);
+        return Result.CREATED();
+    }
+    
+    @Schema(description = "매칭 목록 조회",
+            contentEncoding = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping("/{memberId}")
+    Api<List<MatchingResponseDto>> getMatching(@PathVariable String memberId) {
+        
+        return Api.CREATED(matchingService.getMatchingList(memberId));
+    }
+
+    @Schema(description = "매칭 취소",
+            contentEncoding = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping("/cancel")
+    Result cancelMatching(@RequestBody MatchingRequestDto matchingRequestDto) {
+        
+        matchingService.cancel(matchingRequestDto);
+        
+        return Result.OK();
+    }
+    
+    @Schema(description = "매칭 수락",
+            contentEncoding = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping("/accept")
+    Result acceptMatching(@RequestBody MatchingRequestDto matchingRequestDto) {
+        
+        matchingService.accept(matchingRequestDto);
+        
+        return Result.CREATED();
+    }
+    
+    @Schema(description = "매칭 거절",
+            contentEncoding = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping("/reject")
+    Result rejectMatching(@RequestBody MatchingRequestDto matchingRequestDto) {
+        
+        matchingService.reject(matchingRequestDto);
+        
+        return Result.CREATED();
+    }
+    
+    @Schema(description = "매칭 종료",
+            contentEncoding = MediaType.APPLICATION_JSON_VALUE)
+    @PatchMapping("complete")
+    Result completeMatching(@RequestBody MatchingRequestDto matchingRequestDto) {
+        
+        matchingService.complete(matchingRequestDto);
+                
+        return Result.CREATED();
+    }
     
     
 }

--- a/src/main/java/trendravel/photoravel_be/domain/matching/dto/request/MatchingRequestDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/matching/dto/request/MatchingRequestDto.java
@@ -1,0 +1,17 @@
+package trendravel.photoravel_be.domain.matching.dto.request;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import org.springframework.http.MediaType;
+import trendravel.photoravel_be.db.enums.Region;
+
+@Schema(description = "매칭 요청 DTO", 
+        contentEncoding = MediaType.APPLICATION_JSON_VALUE)
+@Data
+public class MatchingRequestDto {
+    
+    @Schema(description = "유저 계정 ID")
+    private String memberId;
+    @Schema(description = "작가 계정 ID")
+    private String photographerId;
+    
+}

--- a/src/main/java/trendravel/photoravel_be/domain/matching/dto/response/MatchingResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/matching/dto/response/MatchingResponseDto.java
@@ -1,0 +1,25 @@
+package trendravel.photoravel_be.domain.matching.dto.response;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.MediaType;
+import trendravel.photoravel_be.db.enums.Region;
+import trendravel.photoravel_be.db.match.enums.MatchingStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@Schema(description = "매칭 응답 DTO", 
+        contentEncoding = MediaType.APPLICATION_JSON_VALUE)
+public class MatchingResponseDto {
+    
+    @Schema(description = "유저 계정 ID")
+    private String memberId;
+    @Schema(description = "작가 계정 ID")
+    private String photographerId;
+    @Schema(description = "매칭 상태")
+    private MatchingStatus matchingStatus;
+    
+}

--- a/src/main/java/trendravel/photoravel_be/domain/matching/service/MatchingService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/matching/service/MatchingService.java
@@ -1,10 +1,103 @@
 package trendravel.photoravel_be.domain.matching.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import trendravel.photoravel_be.commom.error.MatchingErrorCode;
+import trendravel.photoravel_be.commom.error.MemberErrorCode;
+import trendravel.photoravel_be.commom.error.PhotographerErrorCode;
+import trendravel.photoravel_be.commom.exception.ApiException;
+import trendravel.photoravel_be.db.match.Matching;
+import trendravel.photoravel_be.db.match.enums.MatchingStatus;
+import trendravel.photoravel_be.db.respository.matching.MatchingRepository;
+import trendravel.photoravel_be.db.respository.member.MemberRepository;
+import trendravel.photoravel_be.db.respository.photographer.PhotographerRepository;
+import trendravel.photoravel_be.domain.matching.dto.request.MatchingRequestDto;
+import trendravel.photoravel_be.domain.matching.dto.response.MatchingResponseDto;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MatchingService {
     
+    private final MemberRepository memberRepository;
+    private final PhotographerRepository photographerRepository;
+    private final MatchingRepository matchingRepository;
+    
+    @Transactional
+    public List<MatchingResponseDto> getMatchingList(String memberId) {
+        List<Matching> all = matchingRepository.findByMemberId(memberId);
+        Collections.reverse(all);
+        
+        return all.stream().map(
+                matching -> MatchingResponseDto.builder()
+                        .memberId(matching.getMemberId())
+                        .photographerId(matching.getPhotographerId())
+                        .matchingStatus(matching.getStatus())
+                        .build()
+        ).collect(Collectors.toList());
+    }
+    
+    @Transactional
+    public void pendingMatching(MatchingRequestDto matchingRequestDto) {
+        // 멤버가 존재하는지 검증
+        if (!memberRepository.existsByMemberId(matchingRequestDto.getMemberId())) {
+            throw new ApiException(MemberErrorCode.USER_NOT_FOUND);
+        }
+        
+        // 사진작가가 존재하는지 검증
+        if (!photographerRepository.existsByAccountId(matchingRequestDto.getPhotographerId())) {
+            throw new ApiException(PhotographerErrorCode.PHOTOGRAPHER_NOT_FOUND);
+        }
+        
+        // 멤버가 pending, accept의 매칭을 이미 가지고 있는지 검증
+        boolean memberHasActiveMatching = matchingRepository.existsByMemberIdAndStatusIn(
+                matchingRequestDto.getMemberId(), List.of(MatchingStatus.PENDING, MatchingStatus.ACCEPTED));
+        
+        if (memberHasActiveMatching) {
+            throw new ApiException(MatchingErrorCode.MEMBER_ALREADY_HAS_MATCHING);
+        }
+        
+        matchingRepository.save(Matching.builder()
+                .memberId(matchingRequestDto.getMemberId())
+                .photographerId(matchingRequestDto.getPhotographerId())
+                .status(MatchingStatus.PENDING)
+                .build());
+    }
+    
+    //expectedStatus인 상태의 매칭을 찾아서 newStatus로 수정
+    public void updateMatchingStatus(MatchingRequestDto matchingRequestDto, MatchingStatus newStatus, MatchingStatus expectedStatus) {
+        Matching matching = matchingRepository.findByMemberIdAndStatus(
+                matchingRequestDto.getMemberId(), expectedStatus).orElseThrow(
+                () -> new ApiException(MatchingErrorCode.MATCHING_STATUS_INVALID));
+        
+        matching.updateStatus(newStatus);
+    }
+    
+    // 매칭 취소
+    @Transactional
+    public void cancel(MatchingRequestDto matchingRequestDto) {
+        updateMatchingStatus(matchingRequestDto, MatchingStatus.CANCELED, MatchingStatus.PENDING);
+    }
+    
+    // 사진작가가 수락
+    @Transactional
+    public void accept(MatchingRequestDto matchingRequestDto) {
+        updateMatchingStatus(matchingRequestDto, MatchingStatus.ACCEPTED, MatchingStatus.PENDING);
+    }
+    
+    // 사진작가가 거절
+    @Transactional
+    public void reject(MatchingRequestDto matchingRequestDto) {
+        updateMatchingStatus(matchingRequestDto, MatchingStatus.REJECTED, MatchingStatus.PENDING);
+    }
+    
+    // 사진작가가 완료
+    @Transactional
+    public void complete(MatchingRequestDto matchingRequestDto) {
+        updateMatchingStatus(matchingRequestDto, MatchingStatus.COMPLETED, MatchingStatus.ACCEPTED);
+    }
 }

--- a/src/main/java/trendravel/photoravel_be/domain/matching/service/MatchingService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/matching/service/MatchingService.java
@@ -1,0 +1,10 @@
+package trendravel.photoravel_be.domain.matching.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MatchingService {
+    
+}

--- a/src/main/java/trendravel/photoravel_be/domain/photographer/dto/request/PhotographerRequestDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/photographer/dto/request/PhotographerRequestDto.java
@@ -23,5 +23,7 @@ public class PhotographerRequestDto {
     private Region region;
     @Schema(description = "설명")
     private String description;
+    @Schema(description = "경력")
+    private Integer careerYear;
     
 }

--- a/src/main/java/trendravel/photoravel_be/domain/photographer/dto/request/PhotographerUpdateDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/photographer/dto/request/PhotographerUpdateDto.java
@@ -21,5 +21,6 @@ public class PhotographerUpdateDto {
     private Region region;
     @Schema(description = "설명")
     private String description;
-    
+    @Schema(description = "경력")
+    private Integer careerYear;
 }

--- a/src/main/java/trendravel/photoravel_be/domain/photographer/dto/response/PhotographerListResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/photographer/dto/response/PhotographerListResponseDto.java
@@ -37,5 +37,8 @@ public class PhotographerListResponseDto {
     private LocalDateTime createdAt;
     @Schema(description = "사진작가 계정 수정일")
     private LocalDateTime updatedAt;
-
+    
+    @Schema(description = "경력")
+    private Integer careerYear;
+    
 }

--- a/src/main/java/trendravel/photoravel_be/domain/photographer/dto/response/PhotographerSingleResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/photographer/dto/response/PhotographerSingleResponseDto.java
@@ -40,7 +40,8 @@ public class PhotographerSingleResponseDto {
     private LocalDateTime createdAt;
     @Schema(description = "사진작가 계정 수정일")
     private LocalDateTime updatedAt;
-    
+    @Schema(description = "경력")
+    private Integer careerYear;
     @Schema(description = "최근 리뷰")
     private List<RecentReviewsDto> recentReviewDtos;
     

--- a/src/main/java/trendravel/photoravel_be/domain/photographer/service/PhotographerService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/photographer/service/PhotographerService.java
@@ -54,6 +54,7 @@ public class PhotographerService {
                         .updatedAt(photographer.getUpdatedAt())
                         .ratingAvg(String.format("%.2f", ratingAverage(photographer.getReviews())))
                         .reviewCount(photographer.getReviews().size())
+                        .careerYear(photographer.getCareerYear())
                         .build())
                 .collect(Collectors.toList());
     }
@@ -77,6 +78,7 @@ public class PhotographerService {
                 .createdAt(photographer.getCreatedAt())
                 .updatedAt(photographer.getUpdatedAt())
                 .ratingAvg(String.format("%.2f", ratingAverage(photographer.getReviews())))
+                .careerYear(photographer.getCareerYear())
                 .build();
     }
     
@@ -96,6 +98,7 @@ public class PhotographerService {
                 .description(photographerRequestDto.getDescription())
                 //이미지 업로드 처리는 List이고 엔티티는 문자열이기에 get(0)으로 처리 
                 .profileImg(imageService.uploadImages(images).get(0))
+                .careerYear(photographerRequestDto.getCareerYear())
                 .build());
     }
     
@@ -123,7 +126,7 @@ public class PhotographerService {
         
         photographer.updatePhotographer(photographerUpdateDto, imageService.uploadImages(images));
         
-        //List<RecentReviewsDto> reviews = guideRepository.recentReviews(guide.getId());
+        List<RecentReviewsDto> reviews = photographerRepository.recentReviews(photographer.getId());
         
         return PhotographerSingleResponseDto.builder()
                 .accountId(photographer.getAccountId())
@@ -134,7 +137,8 @@ public class PhotographerService {
                 .createdAt(photographer.getCreatedAt())
                 .updatedAt(photographer.getUpdatedAt())
                 .ratingAvg(String.format("%.2f", ratingAverage(photographer.getReviews())))
-                //.recentReviewDtos(reviews)
+                .recentReviewDtos(reviews)
+                .careerYear(photographer.getCareerYear())
                 .build();
     }
     
@@ -146,7 +150,7 @@ public class PhotographerService {
         
         photographer.updatePhotographer(photographerUpdateDto);
         
-        //List<RecentReviewsDto> reviews = guideRepository.recentReviews(guide.getId());
+        List<RecentReviewsDto> reviews = photographerRepository.recentReviews(photographer.getId());
         
         return PhotographerSingleResponseDto.builder()
                 .accountId(photographer.getAccountId())
@@ -157,7 +161,8 @@ public class PhotographerService {
                 .createdAt(photographer.getCreatedAt())
                 .updatedAt(photographer.getUpdatedAt())
                 .ratingAvg(String.format("%.2f", ratingAverage(photographer.getReviews())))
-                //.recentReviewDtos(reviews)
+                .recentReviewDtos(reviews)
+                .careerYear(photographer.getCareerYear())
                 .build();
     }
     


### PR DESCRIPTION
# 기능 추가
- 매칭 엔티티 추가
  - 매칭은 연관관계가 없고 유저와 사진작가의 유니크 필드(계정 id)를 통해 조작
- 매칭 상태 추가
  - pending
  - accepted
  - rejected
  - canceled
  - completed
- 위 상태변화에 해당하는 기능 구현

![image](https://github.com/user-attachments/assets/7bb0ef52-235e-47a2-ac28-f19d5b50521d)

# 테스트
0. 모든 요청은 유저 id, 사진작가 id 두가지를 서버 측에 전달한다 따라서 이하는 요청 사진 생략
![image](https://github.com/user-attachments/assets/ea9c2000-ad32-43d2-9ce3-affe053fad81)
1. 매칭 요청
![image](https://github.com/user-attachments/assets/e251780c-87b1-48a8-bf59-be2ac2bcde4c)
![image](https://github.com/user-attachments/assets/88c949b9-e5a6-41d0-b7c4-316474954a34)
  유저는 pending 또는 accepted의 매칭을 1개만 가질 수 있다 따라서 요청을 또 보내면 예외 발생

2. 매칭 취소(유저가 취소)
![image](https://github.com/user-attachments/assets/f365661f-24c8-4540-ac70-f33b04314ef4)
![image](https://github.com/user-attachments/assets/d45fcc49-fc66-4217-be2d-96f5f6c7b58b)

3. 매칭 거절(작가가 거절)
![image](https://github.com/user-attachments/assets/0ba9ba1a-5371-4138-ad42-46ed3b0c59a1)
![image](https://github.com/user-attachments/assets/b6c57925-18b2-4c89-8cb8-17ec79f8b7ea)

5. 매칭 수락
![image](https://github.com/user-attachments/assets/fe658f6e-8c3b-4ef2-8005-72a80ba38c36)
![image](https://github.com/user-attachments/assets/8564d30d-32ce-4fc8-b8db-db682f0360f2)

6. 매칭 완료
![image](https://github.com/user-attachments/assets/63731b64-ee85-4278-9c41-89e48db947b0)
![image](https://github.com/user-attachments/assets/cee366a2-e7b9-4b8c-8467-ed13781dbec7)

7. 매칭 조회
![image](https://github.com/user-attachments/assets/c3c33824-5ed1-46a6-adf3-3e61daf75f55)
![image](https://github.com/user-attachments/assets/ca5c8f06-0284-4b97-8d9a-c8ffbc250e0f)


# 추가할 것
전화번호 공유 로직에 대해 아직 구현하지 않음
