### PR TITLE
[Feat/Fix] 컨트롤러 분리, 매칭 READ시 Querydsl 사용/테스트 코드 버그 수정

### DIFF
--- a/src/main/java/trendravel/photoravel_be/db/guidebook/Guidebook.java
+++ b/src/main/java/trendravel/photoravel_be/db/guidebook/Guidebook.java
@@ -32,8 +32,7 @@ public class Guidebook extends BaseEntity {
     @Column(nullable = false)
     private String title;
     
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
     
     

--- a/src/main/java/trendravel/photoravel_be/db/match/Matching.java
+++ b/src/main/java/trendravel/photoravel_be/db/match/Matching.java
@@ -23,11 +23,13 @@ public class Matching {
     private Long id;
     
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private MatchingStatus status;
     
-    
+    @Column(nullable = false, length = 50)
     private String memberId;
-
+    
+    @Column(nullable = false, length = 50)
     private String photographerId;
     
     public void updateStatus(MatchingStatus status) {

--- a/src/main/java/trendravel/photoravel_be/db/respository/matching/MatchingRepositoryCustom.java
+++ b/src/main/java/trendravel/photoravel_be/db/respository/matching/MatchingRepositoryCustom.java
@@ -4,14 +4,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import trendravel.photoravel_be.db.match.Matching;
 import trendravel.photoravel_be.db.match.enums.MatchingStatus;
+import trendravel.photoravel_be.domain.matching.dto.response.MatchingResponseDto;
 
 import java.util.List;
 import java.util.Optional;
 
-@Repository
-public interface MatchingRepository extends JpaRepository<Matching, Long>, MatchingRepositoryCustom {
+public interface MatchingRepositoryCustom {
     
-    boolean existsByMemberIdAndStatusIn(String memberId, List<MatchingStatus> pending);
-    Optional<Matching> findByMemberIdAndStatus(String memberId, MatchingStatus matchingStatus);
+    List<MatchingResponseDto> getMatchingListByMemberId(String memberId);
+    
+    List<MatchingResponseDto> getMatchingListByPhotographerId(String photographerId);
     
 }

--- a/src/main/java/trendravel/photoravel_be/db/respository/matching/MatchingRepositoryImpl.java
+++ b/src/main/java/trendravel/photoravel_be/db/respository/matching/MatchingRepositoryImpl.java
@@ -1,0 +1,53 @@
+package trendravel.photoravel_be.db.respository.matching;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import trendravel.photoravel_be.db.match.Matching;
+import trendravel.photoravel_be.domain.matching.dto.response.MatchingResponseDto;
+
+import java.util.List;
+
+import static trendravel.photoravel_be.db.match.QMatching.matching;
+
+@RequiredArgsConstructor
+public class MatchingRepositoryImpl implements MatchingRepositoryCustom {
+    
+    private final JPAQueryFactory queryFactory;
+    
+    @Override
+    public List<MatchingResponseDto> getMatchingListByMemberId(String memberId) {
+        
+        List<Matching> matchingList = queryFactory
+                .selectFrom(matching)
+                .where(matching.memberId.eq(memberId))
+                .orderBy(matching.id.desc())
+                .fetch();
+        
+        return matchingList.stream()
+                .map(m -> MatchingResponseDto.builder()
+                        .memberId(m.getMemberId())
+                        .photographerId(m.getPhotographerId())
+                        .matchingStatus(m.getStatus())
+                        .build()
+                ).toList();
+    }
+    
+    @Override
+    public List<MatchingResponseDto> getMatchingListByPhotographerId(String photographerId) {
+        
+        List<Matching> matchingList = queryFactory
+                .selectFrom(matching)
+                .where(matching.photographerId.eq(photographerId))
+                .orderBy(matching.id.desc())
+                .fetch();
+        
+        return matchingList.stream()
+                .map(m -> MatchingResponseDto.builder()
+                        .memberId(m.getMemberId())
+                        .photographerId(m.getPhotographerId())
+                        .matchingStatus(m.getStatus())
+                        .build()
+                ).toList();
+    }
+    
+}

--- a/src/main/java/trendravel/photoravel_be/db/respository/member/MemberRepository.java
+++ b/src/main/java/trendravel/photoravel_be/db/respository/member/MemberRepository.java
@@ -10,6 +10,8 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     Optional<MemberEntity> findByEmail(String email);
     Optional<MemberEntity> findByMemberId(String memberId);
     Optional<MemberEntity> findByNickname(String nickname);
+    
+    boolean existsByMemberId(String memberId);
 }
 
 

--- a/src/main/java/trendravel/photoravel_be/domain/guidebook/controller/GuidebookController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/guidebook/controller/GuidebookController.java
@@ -17,7 +17,6 @@ import trendravel.photoravel_be.domain.guidebook.service.GuidebookService;
 import java.util.List;
 
 @RestController
-@RequestMapping("/guidebooks")
 @RequiredArgsConstructor
 public class GuidebookController {
     
@@ -25,7 +24,7 @@ public class GuidebookController {
     
     @Schema(description = "가이드북 CREATE 요청 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PostMapping("/create")
+    @PostMapping("/private/guidebooks/create")
     public Api<GuidebookResponseDto> guidebookCreate(
             @RequestBody GuidebookRequestDto guidebookRequestDto) {
         
@@ -34,7 +33,7 @@ public class GuidebookController {
     
     @Schema(description = "가이드북 CREATE 요청 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PostMapping(value = "/create",
+    @PostMapping(value = "/private/guidebooks/create",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<GuidebookResponseDto> guidebookCreate(
@@ -46,7 +45,7 @@ public class GuidebookController {
     
     
     @Schema(description = "가이드북 목록 READ 요청")
-    @GetMapping
+    @GetMapping("/public/guidebooks")
     public Api<List<GuidebookListResponseDto>> guidebooksList(
             @RequestParam String region) {
         
@@ -54,7 +53,7 @@ public class GuidebookController {
     }
     
     @Schema(description = "가이드북 상제 정보 READ 요청")
-    @GetMapping("/{guidebookId}/detail")
+    @GetMapping("/public/guidebooks/{guidebookId}/detail")
     public Api<GuidebookResponseDto> guidebookDetail(@PathVariable Long guidebookId) {
         
         return Api.READ(guidebookService.getGuidebook(guidebookId));
@@ -62,7 +61,7 @@ public class GuidebookController {
     
     @Schema(description = "가이드북 UPDATE 요청 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PatchMapping("/update")
+    @PatchMapping("/private/guidebooks/update")
     public Api<GuidebookResponseDto> updateGuidebook(
             @RequestBody GuidebookUpdateDto guidebookUpdateDto) {
         
@@ -71,7 +70,7 @@ public class GuidebookController {
     
     @Schema(description = "가이드북 UPDATE 요청 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PatchMapping(value = "/update",
+    @PatchMapping(value = "/private/guidebooks/update",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<GuidebookResponseDto> updateGuidebook(
@@ -82,7 +81,7 @@ public class GuidebookController {
     }
     
     @Schema(description = "가이드북 DELETE 요청")
-    @DeleteMapping("/{guidebookId}/delete")
+    @DeleteMapping("/private/guidebooks/{guidebookId}/delete")
     public Result guidebookDelete(@PathVariable Long guidebookId) {
         
         guidebookService.deleteGuidebook(guidebookId);

--- a/src/main/java/trendravel/photoravel_be/domain/guidebook/service/GuidebookService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/guidebook/service/GuidebookService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.error.GuidebookErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
-import trendravel.photoravel_be.commom.image.service.ImageService;
+import trendravel.photoravel_be.commom.image.service.ImageServiceFacade;
 import trendravel.photoravel_be.domain.guidebook.dto.request.GuidebookRequestDto;
 import trendravel.photoravel_be.domain.guidebook.dto.request.GuidebookUpdateDto;
 import trendravel.photoravel_be.domain.guidebook.dto.request.GuidebookUpdateImageDto;
@@ -16,10 +16,7 @@ import trendravel.photoravel_be.db.guidebook.Guidebook;
 import trendravel.photoravel_be.db.enums.Region;
 import trendravel.photoravel_be.db.respository.guidebook.GuidebookRepository;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,7 +24,7 @@ import java.util.stream.Collectors;
 public class GuidebookService {
     
     private final GuidebookRepository guidebookRepository;
-    private final ImageService imageService;
+    private final ImageServiceFacade imageServiceFacade;
     
     @Transactional
     public GuidebookResponseDto createGuidebook(
@@ -39,7 +36,7 @@ public class GuidebookService {
                 .title(guidebookRequestDto.getTitle())
                 .content(guidebookRequestDto.getContent())
                 .region(guidebookRequestDto.getRegion())
-                .images(imageService.uploadImages(images))
+                .images(imageServiceFacade.uploadImageFacade(images))
                 .views(0)
                 .build());
         
@@ -150,7 +147,7 @@ public class GuidebookService {
         
 
         guidebook.updateGuidebook(guidebookUpdateImageDto,
-                imageService.updateImages(images, guidebookUpdateImageDto.getDeleteImages()));
+                imageServiceFacade.updateImageFacade(images, guidebookUpdateImageDto.getDeleteImages()));
         
         return GuidebookResponseDto.builder()
                 .id(guidebook.getId())
@@ -193,7 +190,7 @@ public class GuidebookService {
         guidebookRepository.deleteById(guidebookId);
         
         if (guidebook.getImages() != null) {
-            imageService.deleteAllImages(guidebook.getImages());
+            imageServiceFacade.deleteAllImagesFacade(guidebook.getImages());
         }
         
     }

--- a/src/main/java/trendravel/photoravel_be/domain/guidebook/service/GuidebookService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/guidebook/service/GuidebookService.java
@@ -100,7 +100,7 @@ public class GuidebookService {
             throw new ApiException(GuidebookErrorCode.GUIDEBOOK_NOT_FOUND);
         }
         
-
+        
         return guidebooks.stream()
                 .map(guidebook -> GuidebookListResponseDto.builder()
                         .id(guidebook.getId())
@@ -108,7 +108,9 @@ public class GuidebookService {
                         .title(guidebook.getTitle())
                         .region(guidebook.getRegion())
                         .views(guidebook.getViews())
-                        .image(!guidebook.getImages().isEmpty() ? guidebook.getImages().get(0) : null)
+                        .image((guidebook.getImages() == null || guidebook.getImages().isEmpty())
+                                ? null
+                                : guidebook.getImages().get(0))
                         .createdAt(guidebook.getCreatedAt())
                         .updatedAt(guidebook.getUpdatedAt())
                         .build())
@@ -145,7 +147,6 @@ public class GuidebookService {
                 () -> new ApiException(GuidebookErrorCode.GUIDEBOOK_NOT_FOUND));
         
         
-
         guidebook.updateGuidebook(guidebookUpdateImageDto,
                 imageServiceFacade.updateImageFacade(images, guidebookUpdateImageDto.getDeleteImages()));
         
@@ -168,7 +169,7 @@ public class GuidebookService {
         Guidebook guidebook = guidebookRepository.findById(guidebookUpdateDto.getId()).orElseThrow(
                 () -> new ApiException(GuidebookErrorCode.GUIDEBOOK_NOT_FOUND));
         
-
+        
         guidebook.updateGuidebook(guidebookUpdateDto);
         
         return GuidebookResponseDto.builder()

--- a/src/main/java/trendravel/photoravel_be/domain/matching/controller/MatchingController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/matching/controller/MatchingController.java
@@ -13,7 +13,6 @@ import trendravel.photoravel_be.domain.matching.service.MatchingService;
 import java.util.List;
 
 @RestController
-@RequestMapping("/matching")
 @RequiredArgsConstructor
 public class MatchingController {
     
@@ -21,7 +20,7 @@ public class MatchingController {
     
     @Schema(description = "매칭 PENDING (CREATE) 요청",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PostMapping("/pending")
+    @PostMapping("/private/matching/pending")
     Result pendingMatching(@RequestBody MatchingRequestDto matchingRequestDto) {
         
         matchingService.pendingMatching(matchingRequestDto);
@@ -30,23 +29,23 @@ public class MatchingController {
     
     @Schema(description = "유저의 매칭 목록 조회",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @GetMapping("/user/{memberId}")
+    @GetMapping("/private/matching/user/{memberId}")
     Api<List<MatchingResponseDto>> getMemberMatching(@PathVariable String memberId) {
         
-        return Api.OK(matchingService.getMatchingList(memberId));
+        return Api.OK(matchingService.getMatchingListByMemberId(memberId));
     }
     
     @Schema(description = "사진작가의 매칭 목록 조회",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @GetMapping("/photographer/{accountId}")
+    @GetMapping("/private/matching/photographer/{accountId}")
     Api<List<MatchingResponseDto>> getPhotographerMatching(@PathVariable String accountId) {
         
-        return Api.OK(matchingService.getMatchingList(accountId));
+        return Api.OK(matchingService.getMatchingListByPhotographerId(accountId));
     }
 
     @Schema(description = "매칭 취소",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PatchMapping("/cancel")
+    @PatchMapping("/private/matching/cancel")
     Result cancelMatching(@RequestBody MatchingRequestDto matchingRequestDto) {
         
         matchingService.cancel(matchingRequestDto);
@@ -56,7 +55,7 @@ public class MatchingController {
     
     @Schema(description = "매칭 수락",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PatchMapping("/accept")
+    @PatchMapping("/private/matching/accept")
     Result acceptMatching(@RequestBody MatchingRequestDto matchingRequestDto) {
         
         matchingService.accept(matchingRequestDto);
@@ -66,7 +65,7 @@ public class MatchingController {
     
     @Schema(description = "매칭 거절",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PatchMapping("/reject")
+    @PatchMapping("/private/matching/reject")
     Result rejectMatching(@RequestBody MatchingRequestDto matchingRequestDto) {
         
         matchingService.reject(matchingRequestDto);
@@ -76,7 +75,7 @@ public class MatchingController {
     
     @Schema(description = "매칭 종료",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PatchMapping("complete")
+    @PatchMapping("/private/matching/complete")
     Result completeMatching(@RequestBody MatchingRequestDto matchingRequestDto) {
         
         matchingService.complete(matchingRequestDto);

--- a/src/main/java/trendravel/photoravel_be/domain/matching/service/MatchingService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/matching/service/MatchingService.java
@@ -28,17 +28,13 @@ public class MatchingService {
     private final MatchingRepository matchingRepository;
     
     @Transactional
-    public List<MatchingResponseDto> getMatchingList(String memberId) {
-        List<Matching> all = matchingRepository.findByMemberId(memberId);
-        Collections.reverse(all);
-        
-        return all.stream().map(
-                matching -> MatchingResponseDto.builder()
-                        .memberId(matching.getMemberId())
-                        .photographerId(matching.getPhotographerId())
-                        .matchingStatus(matching.getStatus())
-                        .build()
-        ).collect(Collectors.toList());
+    public List<MatchingResponseDto> getMatchingListByMemberId(String memberId) {
+        return matchingRepository.getMatchingListByMemberId(memberId);
+    }
+    
+    @Transactional
+    public List<MatchingResponseDto> getMatchingListByPhotographerId(String accountId) {
+        return matchingRepository.getMatchingListByPhotographerId(accountId);
     }
     
     @Transactional

--- a/src/main/java/trendravel/photoravel_be/domain/photographer/controller/PhotographerController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/photographer/controller/PhotographerController.java
@@ -17,7 +17,6 @@ import trendravel.photoravel_be.domain.photographer.service.PhotographerService;
 import java.util.List;
 
 @RestController
-@RequestMapping("/photographers")
 @RequiredArgsConstructor
 public class PhotographerController {
     
@@ -25,7 +24,7 @@ public class PhotographerController {
     
     @Schema(description = "사진작가 회원 가입(CREATE) 요청",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PostMapping(value = "/join",
+    @PostMapping(value = "/private/photographers/join",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Result createPhotographer(
@@ -39,7 +38,7 @@ public class PhotographerController {
     
     @Schema(description = "사진작가 로그인 요청",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PostMapping("/login")
+    @PostMapping("/public/photographers/login")
     public Result loginPhotographer(@RequestBody PhotographerLoginRequestDto loginRequestDto) {
         
         photographerService.authenticate(loginRequestDto.getUsername(),
@@ -50,14 +49,14 @@ public class PhotographerController {
     
     @Schema(description = "사진작가 목록 READ 요청",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @GetMapping
+    @GetMapping("/public/photographers")
     public Api<List<PhotographerListResponseDto>> getPhotographerList(@RequestParam String region) {
         
         return Api.READ(photographerService.getPhotographerList(region));
     }
     
     @Schema(description = "사진작가 상세 정보 READ 요청")
-    @GetMapping("/{photographerId}/detail")
+    @GetMapping("/public/photographers/{photographerId}/detail")
     public Api<PhotographerSingleResponseDto> getPhotographer(@PathVariable String photographerId) {
         
         return Api.READ(photographerService.getPhotographer(photographerId));
@@ -66,7 +65,7 @@ public class PhotographerController {
     
     @Schema(description = "사진작가 정보 UPDATE 요청 (이미지 미포함)",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @PatchMapping("/update")
+    @PatchMapping("/private/photographers/update")
     public Api<PhotographerSingleResponseDto> updatePhotographer(
             @RequestBody PhotographerUpdateDto photographerUpdateDto) {
         
@@ -75,7 +74,7 @@ public class PhotographerController {
     
     @Schema(description = "사진작가 정보 UPDATE 요청 (이미지 포함)",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PatchMapping(value = "/update",
+    @PatchMapping(value = "/private/photographers/update",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<PhotographerSingleResponseDto> updatePhotographer(
@@ -89,7 +88,7 @@ public class PhotographerController {
     
     @Schema(description = "사진작가 정보 DELETE 요청",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
-    @DeleteMapping("/{photographerId}/delete")
+    @DeleteMapping("/private/photographers/{photographerId}/delete")
     public Result deletePhotographer(@PathVariable String photographerId) {
         
         photographerService.deletePhotographer(photographerId);

--- a/src/main/java/trendravel/photoravel_be/domain/photographer/controller/PhotographerController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/photographer/controller/PhotographerController.java
@@ -24,7 +24,7 @@ public class PhotographerController {
     
     @Schema(description = "사진작가 회원 가입(CREATE) 요청",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PostMapping(value = "/private/photographers/join",
+    @PostMapping(value = "/public/photographers/join",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Result createPhotographer(

--- a/src/main/java/trendravel/photoravel_be/domain/photographer/service/PhotographerService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/photographer/service/PhotographerService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.error.PhotographerErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
-import trendravel.photoravel_be.commom.image.service.ImageService;
+import trendravel.photoravel_be.commom.image.service.ImageServiceFacade;
 import trendravel.photoravel_be.db.enums.Region;
 import trendravel.photoravel_be.db.photographer.Photographer;
 import trendravel.photoravel_be.db.respository.photographer.PhotographerRepository;
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 public class PhotographerService {
     
     private final PhotographerRepository photographerRepository;
-    private final ImageService imageService;
+    private final ImageServiceFacade imageServiceFacade;
     
     @Transactional
     public List<PhotographerListResponseDto> getPhotographerList(String region) {
@@ -97,7 +97,7 @@ public class PhotographerService {
                 .region(photographerRequestDto.getRegion())
                 .description(photographerRequestDto.getDescription())
                 //이미지 업로드 처리는 List이고 엔티티는 문자열이기에 get(0)으로 처리 
-                .profileImg(imageService.uploadImages(images).get(0))
+                .profileImg(imageServiceFacade.uploadImageFacade(images).get(0))
                 .careerYear(photographerRequestDto.getCareerYear())
                 .build());
     }
@@ -122,9 +122,9 @@ public class PhotographerService {
         //기존 이미지 삭제
         List<String> originImage = new ArrayList<>();
         originImage.add(photographer.getProfileImg());
-        imageService.deleteAllImages(originImage);
+        imageServiceFacade.deleteAllImagesFacade(originImage);
         
-        photographer.updatePhotographer(photographerUpdateDto, imageService.uploadImages(images));
+        photographer.updatePhotographer(photographerUpdateDto, imageServiceFacade.uploadImageFacade(images));
         
         List<RecentReviewsDto> reviews = photographerRepository.recentReviews(photographer.getId());
         
@@ -171,6 +171,10 @@ public class PhotographerService {
         
         Photographer photographer = photographerRepository.findByAccountId(photographerId).orElseThrow(
                 () -> new ApiException(PhotographerErrorCode.PHOTOGRAPHER_NOT_FOUND));
+        
+        List<String> img = new ArrayList<>();
+        img.add(photographer.getProfileImg());
+        imageServiceFacade.deleteAllImagesFacade(img);
         
         photographerRepository.deleteByAccountId(photographerId);
         

--- a/src/test/java/trendravel/photoravel_be/entity/GuidebookTest.java
+++ b/src/test/java/trendravel/photoravel_be/entity/GuidebookTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import trendravel.photoravel_be.db.enums.Region;
 import trendravel.photoravel_be.db.guidebook.Guidebook;
 import trendravel.photoravel_be.domain.guidebook.dto.request.GuidebookRequestDto;
+import trendravel.photoravel_be.domain.guidebook.dto.request.GuidebookUpdateDto;
+import trendravel.photoravel_be.domain.guidebook.dto.request.GuidebookUpdateImageDto;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,27 +59,23 @@ public class GuidebookTest {
                 .userId(1L)
                 .title("아산 여행하기")
                 .content("이것은 내용")
-                .images(image)
                 .region(Region.아산)
                 .views(2)
                 .build();
         
-        GuidebookRequestDto guidebookRequestDto = new GuidebookRequestDto();
-        guidebookRequestDto.setTitle("수정된 제목");
-        guidebookRequestDto.setContent("수정된 내용");
-        guidebookRequestDto.setRegion(Region.천안);
+        GuidebookUpdateDto guidebookUpdateDto = new GuidebookUpdateDto();
+        guidebookUpdateDto.setTitle("수정된 제목");
+        guidebookUpdateDto.setContent("수정된 내용");
+        guidebookUpdateDto.setRegion(Region.천안);
         
         //when
-        image.add("이미지 url 2");
-        //guidebook.updateGuidebook(guidebookRequestDto, image);
+        guidebook.updateGuidebook(guidebookUpdateDto);
         
         //then
         assertThat(guidebook.getTitle()).isEqualTo("수정된 제목");
         assertThat(guidebook.getContent()).isEqualTo("수정된 내용");
         assertThat(guidebook.getRegion()).isEqualTo(Region.천안);
-        for (String guidebookImage : guidebook.getImages()) {
-            assertThat(guidebookImage).isIn(image);
-        }
+        
         
     }
     

--- a/src/test/java/trendravel/photoravel_be/entity/PhotographerTest.java
+++ b/src/test/java/trendravel/photoravel_be/entity/PhotographerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import trendravel.photoravel_be.db.enums.Region;
 import trendravel.photoravel_be.db.photographer.Photographer;
 import trendravel.photoravel_be.domain.photographer.dto.request.PhotographerRequestDto;
+import trendravel.photoravel_be.domain.photographer.dto.request.PhotographerUpdateDto;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,18 +60,18 @@ public class PhotographerTest {
                 .profileImg(profileImg)
                 .build();
         
-        PhotographerRequestDto photographerRequestDto = new PhotographerRequestDto();
-        photographerRequestDto.setPassword("4321");
-        photographerRequestDto.setName("김동욱");
-        photographerRequestDto.setRegion(Region.천안);
-        photographerRequestDto.setDescription("설명 수정");
+        PhotographerUpdateDto photographerUpdateDto = new PhotographerUpdateDto();
+        photographerUpdateDto.setPassword("4321");
+        photographerUpdateDto.setName("김동욱");
+        photographerUpdateDto.setRegion(Region.천안);
+        photographerUpdateDto.setDescription("설명 수정");
         
         List<String> profileImgList = new ArrayList<>();
         
         //when
         profileImg = "이미지 url 2";
         profileImgList.add(profileImg);
-        //photographer.updatePhotographer(photographerRequestDto, profileImgList);
+        photographer.updatePhotographer(photographerUpdateDto, profileImgList);
         
         //then
         assertThat(photographer.getPassword()).isEqualTo("4321");

--- a/src/test/java/trendravel/photoravel_be/repository/PhotographerRepositoryTest.java
+++ b/src/test/java/trendravel/photoravel_be/repository/PhotographerRepositoryTest.java
@@ -37,6 +37,7 @@ public class PhotographerRepositoryTest {
                 .region(Region.아산)
                 .description("신동욱입니다")
                 .profileImg(profileImg)
+                .careerYear(1)
                 .build();
     }
     

--- a/src/test/java/trendravel/photoravel_be/service/PhotographerServiceTest.java
+++ b/src/test/java/trendravel/photoravel_be/service/PhotographerServiceTest.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.error.GuidebookErrorCode;
 import trendravel.photoravel_be.commom.error.PhotographerErrorCode;
@@ -17,6 +18,11 @@ import trendravel.photoravel_be.domain.photographer.dto.response.PhotographerLis
 import trendravel.photoravel_be.domain.photographer.dto.response.PhotographerSingleResponseDto;
 import trendravel.photoravel_be.domain.photographer.service.PhotographerService;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
@@ -34,10 +40,18 @@ public class PhotographerServiceTest {
     
     PhotographerRequestDto photo1, photo2;
     PhotographerUpdateDto photographerUpdateDto;
-    List<MultipartFile> list;
+    
+    
+    MockMultipartFile mockMultipartFile;
     
     @BeforeEach
-    void before() {
+    void before() throws IOException {
+        
+        //   resource/images/test.png
+        URL resource = getClass().getClassLoader().getResource("images/test.png");
+        mockMultipartFile = new MockMultipartFile("image",
+                "test.png", "image/png", new FileInputStream(resource.getFile()));
+        
         
         photo1 = new PhotographerRequestDto();
         photo1.setAccountId("아이디");
@@ -45,6 +59,7 @@ public class PhotographerServiceTest {
         photo1.setDescription("설명");
         photo1.setName("신동욱");
         photo1.setRegion(Region.아산);
+        photo1.setCareerYear(1);
         
         photo2 = new PhotographerRequestDto();
         photo2.setAccountId("아이디22");
@@ -52,6 +67,7 @@ public class PhotographerServiceTest {
         photo2.setDescription("설명22");
         photo2.setName("김동욱");
         photo2.setRegion(Region.천안);
+        photo2.setCareerYear(2);
         
         photographerUpdateDto = new PhotographerUpdateDto();
         photographerUpdateDto.setAccountId("아이디"); //수정용 아니고 검색용
@@ -61,13 +77,15 @@ public class PhotographerServiceTest {
         photographerUpdateDto.setRegion(Region.천안);
         
         
-        list = null;
     }
     
     @Test
     @Order(1)
     @DisplayName("사진작가 CREATE 테스트")
     void create() {
+        
+        List<MultipartFile> list = new ArrayList<>();
+        list.add(mockMultipartFile);
         
         //when
         photographerService.createPhotographer(photo1, list);
@@ -86,6 +104,8 @@ public class PhotographerServiceTest {
     void getList() {
         
         //given
+        List<MultipartFile> list = new ArrayList<>();
+        list.add(mockMultipartFile);
         photographerService.createPhotographer(photo1, list);
         photographerService.createPhotographer(photo2, list);
         
@@ -105,6 +125,8 @@ public class PhotographerServiceTest {
     void getOne() {
         
         //given
+        List<MultipartFile> list = new ArrayList<>();
+        list.add(mockMultipartFile);
         photographerService.createPhotographer(photo1, list);
         
         //when
@@ -122,6 +144,8 @@ public class PhotographerServiceTest {
     void update() {
         
         //given
+        List<MultipartFile> list = new ArrayList<>();
+        list.add(mockMultipartFile);
         photographerService.createPhotographer(photo1, list);
         
         //when
@@ -140,6 +164,8 @@ public class PhotographerServiceTest {
     void delete() {
         
         //given
+        List<MultipartFile> list = new ArrayList<>();
+        list.add(mockMultipartFile);
         photographerService.createPhotographer(photo1, list);
         
         //when


### PR DESCRIPTION
# 수정사항
- 컨트롤러 분리
- 매칭 조회 시 쿼리 dsl 사용
- 사진작가 테스트 코드 버그 수정

# 컨트롤러 분리
- 사진작가, 가이드북, 매칭 컨트롤러 URL private/public 분리

# 매칭 조회 시 쿼리 dsl 사용
-  조회 시 멤버 id, 사진작가 id 분리
![image](https://github.com/user-attachments/assets/ed3bbdac-3608-4c48-9189-fe29a7b0b10d)
![image](https://github.com/user-attachments/assets/7bd57c7b-8263-40fd-b0ed-6490a5c499ac)

# 사진작가 테스트 코드 버그 수정
- #26 의 사진작가 테스트 코드 버그 수정
- 원인
  - 사진작가 생성은 이미지를 반드시 포함해야 함
  - 이 때 이미지를 넣어준 객체가 null로 지정 하여 테스트를 작성
  - ImageService 대신 ImageServiceFacade 
  - 따라서 테스트 실패
- 해결 방법
  - 가짜 이미지 mock 객체를 생성하여 해결
  - 이미지 조회 시 null 검사 로직 추가
  - resource/images/test.png 필요(커밋에 미포함)
  
  ![image](https://github.com/user-attachments/assets/205db5b0-c071-4cd9-97f5-22ae0751ec08)
  ![image](https://github.com/user-attachments/assets/62a1654d-6df1-42a3-9b36-900cdfc1aae4)
  ![image](https://github.com/user-attachments/assets/b7e79271-be97-412d-a6a0-129729986c1d)
  ![image](https://github.com/user-attachments/assets/8b6e31f3-a6de-4081-adb9-fd10e118ec26)

# 나머지 테스트 코드 자잘한 버그 수정
  ![image](https://github.com/user-attachments/assets/fe02a608-2645-45ff-a25a-ef391badbfde)
  ![image](https://github.com/user-attachments/assets/77f5ccbe-411b-4ea0-b8b8-593494027c22)
  ![image](https://github.com/user-attachments/assets/b159132c-abfc-4029-8dc2-0afd00aa68aa)
  ![image](https://github.com/user-attachments/assets/e80ba072-cc81-408b-94be-732ab57af07d)


# 다음 목표
- 유저 - 가이드북 연관관계 설정