### PR TITLE
[Feat/Refactor] 사진작가 인증 인가 구현 및 멤버 약간의 리팩토링

### DIFF
--- a/src/main/java/trendravel/photoravel_be/commom/accessHandler/JwtAccessDeniedHandler.java
+++ b/src/main/java/trendravel/photoravel_be/commom/accessHandler/JwtAccessDeniedHandler.java
@@ -1,0 +1,42 @@
+package trendravel.photoravel_be.commom.accessHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import trendravel.photoravel_be.commom.error.ErrorCode;
+import trendravel.photoravel_be.commom.response.Api;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, org.springframework.security.access.AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        log.info("JwtAuthenticationEntryPoint 진입");
+
+        Api<Object> apiResponse = Api.ERROR(ErrorCode.FORBIDDEN_ERROR);
+
+        String responseBody = objectMapper.writeValueAsString(apiResponse);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setCharacterEncoding("UTF-8");
+        try {
+            response.getWriter().write(responseBody);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/commom/entryPoint/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/trendravel/photoravel_be/commom/entryPoint/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,46 @@
+package trendravel.photoravel_be.commom.entryPoint;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import trendravel.photoravel_be.commom.error.ErrorCode;
+import trendravel.photoravel_be.commom.exception.ApiException;
+import trendravel.photoravel_be.commom.response.Api;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+        log.info("JwtAuthenticationEntryPoint 진입");
+
+        ApiException apiException = new ApiException(ErrorCode.UNAUTHORIZED_ERROR);
+
+        Api<Object> apiResponse = Api.ERROR(ErrorCode.UNAUTHORIZED_ERROR);
+
+        String responseBody = objectMapper.writeValueAsString(apiResponse);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/commom/error/MemberErrorCode.java
+++ b/src/main/java/trendravel/photoravel_be/commom/error/MemberErrorCode.java
@@ -12,7 +12,7 @@ public enum MemberErrorCode implements ErrorCodeIfs{
     EXISTS_USER(400, "이미 존재하는 회원입니다."),
     PASSWORD_NOT_MATCH(400, "패스워드가 일치하지 않습니다."),
     MEMBER_ID_NOT_MATCH(400, "아이디가 일치하지 않습니다."),
-    UNAUTHORIZED(401, "인증되지 않았습니다.")
+    UNAUTHORIZED(401, "자신의 정보만 접근 가능합니다.")
     ;
 
     private final Integer httpStatusCode;

--- a/src/main/java/trendravel/photoravel_be/commom/error/PhotographerErrorCode.java
+++ b/src/main/java/trendravel/photoravel_be/commom/error/PhotographerErrorCode.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum PhotographerErrorCode implements ErrorCodeIfs{
     
-    PHOTOGRAPHER_NOT_FOUND(404, "사진작가를 찾을 수 없음");
+    PHOTOGRAPHER_NOT_FOUND(404, "사진작가를 찾을 수 없음"),
+    UNAUTHORIZED(401, "자신의 정보만 접근 가능합니다.");
 
 
     private final Integer httpStatusCode;

--- a/src/main/java/trendravel/photoravel_be/db/photographer/Photographer.java
+++ b/src/main/java/trendravel/photoravel_be/db/photographer/Photographer.java
@@ -32,7 +32,7 @@ public class Photographer extends BaseEntity {
     @Column(length = 50, nullable = false, unique = true)
     private String accountId;
     
-    @Column(length = 50, nullable = false)
+    @Column(length = 255, nullable = false)
     private String password;
     
     @Column(length = 50, nullable = false)
@@ -55,6 +55,7 @@ public class Photographer extends BaseEntity {
     
     //images 타입에 대해 수정 필요 imageService 단에서 하나의 이미지를 처리하는 메서드 필요
     public void updatePhotographer(PhotographerUpdateDto photographerUpdateDto, List<String> images) {
+        this.accountId = photographerUpdateDto.getAccountId();
         this.password = photographerUpdateDto.getPassword();
         this.name = photographerUpdateDto.getName();
         this.region = photographerUpdateDto.getRegion();
@@ -63,6 +64,7 @@ public class Photographer extends BaseEntity {
     }
     
     public void updatePhotographer(PhotographerUpdateDto photographerUpdateDto) {
+        this.accountId = photographerUpdateDto.getAccountId();
         this.password = photographerUpdateDto.getPassword();
         this.name = photographerUpdateDto.getName();
         this.region = photographerUpdateDto.getRegion();

--- a/src/main/java/trendravel/photoravel_be/domain/authentication/controller/LoginController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/authentication/controller/LoginController.java
@@ -31,7 +31,7 @@ public class LoginController {
     }
 
     @GetMapping("/oauth2/code/{provider}")
-    public ResponseEntity<?> authorized(@PathVariable String provider, @RequestParam("code") String code, HttpServletResponse response) {
+    public ResponseEntity<?> authorized(@PathVariable String provider, @RequestParam("code") String code) {
         log.info("authorized - provider : {}, code : {}", provider, code);
         return socialLoginService.connectToSocialLogin(provider, code);
     }

--- a/src/main/java/trendravel/photoravel_be/domain/authentication/service/MemberAuthenticationService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/authentication/service/MemberAuthenticationService.java
@@ -10,9 +10,8 @@ import trendravel.photoravel_be.db.member.MemberEntity;
 import trendravel.photoravel_be.db.respository.member.MemberRepository;
 import trendravel.photoravel_be.domain.authentication.session.UserSession;
 
-@Service
 @RequiredArgsConstructor
-public class AuthenticationService implements UserDetailsService {
+public class MemberAuthenticationService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
 
@@ -28,11 +27,13 @@ public class AuthenticationService implements UserDetailsService {
         return UserSession.builder()
                 .email(memberEntity.getEmail())
                 .memberId(memberEntity.getMemberId())
+                .password(memberEntity.getPassword())
                 .name(memberEntity.getName())
                 .nickname(memberEntity.getNickname())
                 .profileImg(memberEntity.getProfileImg())
                 .createdAt(memberEntity.getCreatedAt())
                 .updatedAt(memberEntity.getUpdatedAt())
+                .role("ROLE_MEMBER")
                 .build();
     }
 }

--- a/src/main/java/trendravel/photoravel_be/domain/authentication/service/PhotographerAuthenticationService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/authentication/service/PhotographerAuthenticationService.java
@@ -1,0 +1,40 @@
+package trendravel.photoravel_be.domain.authentication.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import trendravel.photoravel_be.db.photographer.Photographer;
+import trendravel.photoravel_be.db.respository.photographer.PhotographerRepository;
+import trendravel.photoravel_be.domain.authentication.session.PhotographerSession;
+
+@Service("photographerAuthenticationService")
+@RequiredArgsConstructor
+public class PhotographerAuthenticationService implements UserDetailsService {
+
+    private final PhotographerRepository photographerRepository;
+
+    @Transactional
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Photographer photographer = photographerRepository.findByAccountId(username)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사진작가입니다."));
+
+        return PhotographerSession.builder()
+                .accountId(photographer.getAccountId())
+                .password(photographer.getPassword())
+                .name(photographer.getName())
+                .region(photographer.getRegion())
+                .description(photographer.getDescription())
+                .profileImg(photographer.getProfileImg())
+                .careerYear(photographer.getCareerYear())
+                .matchingCount(photographer.getMatchingCount())
+                .createdAt(photographer.getCreatedAt())
+                .updatedAt(photographer.getUpdatedAt())
+                .role("ROLE_PHOTOGRAPHER")
+                .build();
+        }
+}

--- a/src/main/java/trendravel/photoravel_be/domain/authentication/session/PhotographerSession.java
+++ b/src/main/java/trendravel/photoravel_be/domain/authentication/session/PhotographerSession.java
@@ -1,0 +1,72 @@
+package trendravel.photoravel_be.domain.authentication.session;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import trendravel.photoravel_be.db.enums.Region;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PhotographerSession implements UserDetails {
+
+    private String accountId;
+    private String password;
+    private String name;
+    private Region region;
+    private String description;
+    private String profileImg;
+    private Integer careerYear;
+    private Integer matchingCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String role;
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_PHOTOGRAPHER"));
+
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    // 메소드 명은 시큐리티 기본으로 username이지만
+    //* !!!! IMPORTANT !!!! *
+
+    // 실제로 내부 로직에서 사용하는 것은 memberId입니다.
+    @Override
+    public String getUsername() {
+        return accountId;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/trendravel/photoravel_be/domain/authentication/session/UserSession.java
+++ b/src/main/java/trendravel/photoravel_be/domain/authentication/session/UserSession.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
@@ -23,11 +24,12 @@ public class UserSession implements UserDetails {
     private String profileImg;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private String role;
 
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.emptyList(); // 빈 권한 리스트
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_MEMBER"));
     }
 
     @Override

--- a/src/main/java/trendravel/photoravel_be/domain/member/controller/MemberPrivateController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/controller/MemberPrivateController.java
@@ -17,14 +17,6 @@ public class MemberPrivateController {
 
     private final MemberService memberService;
 
-    @GetMapping("/info/{memberId}")
-    public Api<MemberResponse> getMemberInfo(
-            @PathVariable String memberId
-    ) {
-        MemberResponse response = memberService.getMemberInfo(memberId);
-        return Api.OK(response);
-    }
-
     @PatchMapping(value = "/info",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/trendravel/photoravel_be/domain/member/controller/MemberPublicController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/controller/MemberPublicController.java
@@ -19,13 +19,15 @@ public class MemberPublicController {
 
     private final MemberService memberService;
 
-    @PatchMapping(value = "/register",
+    @PostMapping(value = "/register",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public Api<MemberResponse> localRegister(
             @RequestPart(value = "request") MemberRegisterRequest request,
             @RequestPart(value = "image") MultipartFile image
             ) {
+        // 생각해보니 이미지를 필수로 넣어야하나?
+        // 이미지를 첨부하지 않으면 default img가 필요할 것 같은데..
         MemberResponse response = memberService.localRegister(request, image);
 
         return Api.CREATED(response);
@@ -39,6 +41,13 @@ public class MemberPublicController {
         return Api.OK(response);
     }
 
+    @GetMapping("/info/{memberId}")
+    public Api<MemberResponse> getMemberInfo(
+            @PathVariable String memberId
+    ) {
+        MemberResponse response = memberService.getMemberInfo(memberId);
+        return Api.OK(response);
+    }
 
     @GetMapping("/{email}/email-check")
     public Api<MemberInfoCheckResponse> emailCheck(

--- a/src/main/java/trendravel/photoravel_be/domain/member/convertor/MemberConvertor.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/convertor/MemberConvertor.java
@@ -12,7 +12,6 @@ public class MemberConvertor {
         return MemberResponse.builder()
                 .memberId(saved.getMemberId())
                 .email(saved.getEmail())
-                .password(saved.getPassword())
                 .name(saved.getName())
                 .nickname(saved.getNickname())
                 .profileImg(saved.getProfileImg())

--- a/src/main/java/trendravel/photoravel_be/domain/member/dto/MemberResponse.java
+++ b/src/main/java/trendravel/photoravel_be/domain/member/dto/MemberResponse.java
@@ -15,7 +15,6 @@ public class MemberResponse {
 
     private String memberId;
     private String email;
-    private String password;
     private String name;
     private String nickname;
     private String profileImg;

--- a/src/main/java/trendravel/photoravel_be/domain/photographer/controller/PhotographerController.java
+++ b/src/main/java/trendravel/photoravel_be/domain/photographer/controller/PhotographerController.java
@@ -2,17 +2,26 @@ package trendravel.photoravel_be.domain.photographer.controller;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import trendravel.photoravel_be.commom.response.Api;
 import trendravel.photoravel_be.commom.response.Result;
+import trendravel.photoravel_be.db.inmemorydb.entity.Token;
+import trendravel.photoravel_be.domain.authentication.dto.RefreshTokenRequest;
 import trendravel.photoravel_be.domain.photographer.dto.request.PhotographerLoginRequestDto;
 import trendravel.photoravel_be.domain.photographer.dto.request.PhotographerRequestDto;
 import trendravel.photoravel_be.domain.photographer.dto.request.PhotographerUpdateDto;
 import trendravel.photoravel_be.domain.photographer.dto.response.PhotographerListResponseDto;
 import trendravel.photoravel_be.domain.photographer.dto.response.PhotographerSingleResponseDto;
 import trendravel.photoravel_be.domain.photographer.service.PhotographerService;
+import trendravel.photoravel_be.domain.token.model.TokenDto;
+import trendravel.photoravel_be.domain.token.model.TokenResponse;
+import trendravel.photoravel_be.domain.token.service.TokenService;
 
 import java.util.List;
 
@@ -21,6 +30,8 @@ import java.util.List;
 public class PhotographerController {
     
     private final PhotographerService photographerService;
+    private final TokenService tokenService;
+    private final RedisTemplate<String, Token> redisTemplate;
 
     @Schema(description = "사진작가 회원 가입(CREATE) 요청",
             contentEncoding = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -39,12 +50,12 @@ public class PhotographerController {
     @Schema(description = "사진작가 로그인 요청",
             contentEncoding = MediaType.APPLICATION_JSON_VALUE)
     @PostMapping("/public/photographers/login")
-    public Result loginPhotographer(@RequestBody PhotographerLoginRequestDto loginRequestDto) {
+    public Api<TokenResponse> loginPhotographer(@RequestBody PhotographerLoginRequestDto loginRequestDto) {
 
-        photographerService.authenticate(loginRequestDto.getUsername(),
+        TokenResponse response = photographerService.authenticate(loginRequestDto.getUsername(),
                 loginRequestDto.getPassword());
 
-        return Result.OK();
+        return Api.OK(response);
     }
 
     @Schema(description = "사진작가 목록 READ 요청",
@@ -93,6 +104,45 @@ public class PhotographerController {
         
         photographerService.deletePhotographer(photographerId);
         return Result.DELETED();
+    }
+
+    @PostMapping("/private/photographers/logout")
+    public Api<?> logout(@RequestBody RefreshTokenRequest request) {
+
+        String refreshToken = request.getRefreshToken();
+
+        // accountId null check는 validation 메소드 안에서 이미 진행
+        String accountId = tokenService.validationTokenWithAccountId(refreshToken);
+
+        // 소셜 로그인 및 로컬 로그인 모두 로그아웃 프로세스는 동일
+        redisTemplate.opsForHash().delete("photographer_refresh_token", accountId);
+        // 저장된 컨텍스트 안의 principal 삭제
+        SecurityContextHolder.clearContext();
+
+        return Api.OK("로그아웃되었습니다.");
+    }
+
+    @PostMapping("/private/photographers/refresh-token")
+    public ResponseEntity<Api<Object>> refreshAccessToken(
+            @RequestBody RefreshTokenRequest request
+    ) {
+
+        String accountId = tokenService.validationTokenWithAccountId(request.getRefreshToken());
+
+        Token storedRefreshToken = (Token) redisTemplate.opsForHash().get("photographer_refresh_token", accountId);
+
+        // 레디스에 리프레쉬 토큰이 저장되어 있는지 && 요청으로 보낸 토큰과 레디스에 저장된 토큰이 일치하는지
+        if (storedRefreshToken != null && request.getRefreshToken().equals(storedRefreshToken.getRefreshToken())) {
+            // 정상적인 경우 액세스 토큰 재발급
+            TokenDto accessToken = tokenService.issuePhotographerAccessToken(accountId);
+            return ResponseEntity.ok(Api.OK(accessToken));
+        } else {
+            // http status code를 명확히 하기 위해 ResponseEntity 사용
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(Api.ERROR(400, "Invalid refresh token"));
+            // 정상적이지 않은 경우 bad request
+        }
     }
     
 }

--- a/src/main/java/trendravel/photoravel_be/domain/photographer/dto/response/PhotographerSingleResponseDto.java
+++ b/src/main/java/trendravel/photoravel_be/domain/photographer/dto/response/PhotographerSingleResponseDto.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import org.springframework.http.MediaType;
 import trendravel.photoravel_be.db.enums.Region;
 import trendravel.photoravel_be.domain.review.dto.response.RecentReviewsDto;
+import trendravel.photoravel_be.domain.token.model.TokenResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -47,4 +48,7 @@ public class PhotographerSingleResponseDto {
     
     @Schema(description = "매칭 횟수")
     private Integer matchingCount;
+
+    @Schema(description = "새로 발급된 토큰")
+    private TokenResponse tokenResponse;
 }

--- a/src/main/java/trendravel/photoravel_be/domain/photographer/service/PhotographerService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/photographer/service/PhotographerService.java
@@ -2,20 +2,32 @@ package trendravel.photoravel_be.domain.photographer.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import trendravel.photoravel_be.commom.error.MemberErrorCode;
 import trendravel.photoravel_be.commom.error.PhotographerErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
 import trendravel.photoravel_be.commom.image.service.ImageServiceFacade;
 import trendravel.photoravel_be.db.enums.Region;
+import trendravel.photoravel_be.db.inmemorydb.entity.Token;
 import trendravel.photoravel_be.db.photographer.Photographer;
 import trendravel.photoravel_be.db.respository.photographer.PhotographerRepository;
 import trendravel.photoravel_be.db.review.Review;
+import trendravel.photoravel_be.domain.authentication.service.PhotographerAuthenticationService;
+import trendravel.photoravel_be.domain.authentication.session.PhotographerSession;
 import trendravel.photoravel_be.domain.photographer.dto.request.PhotographerRequestDto;
 import trendravel.photoravel_be.domain.photographer.dto.request.PhotographerUpdateDto;
 import trendravel.photoravel_be.domain.photographer.dto.response.PhotographerListResponseDto;
 import trendravel.photoravel_be.domain.photographer.dto.response.PhotographerSingleResponseDto;
 import trendravel.photoravel_be.domain.review.dto.response.RecentReviewsDto;
+import trendravel.photoravel_be.domain.token.model.TokenDto;
+import trendravel.photoravel_be.domain.token.model.TokenResponse;
+import trendravel.photoravel_be.domain.token.service.TokenService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +39,10 @@ public class PhotographerService {
     
     private final PhotographerRepository photographerRepository;
     private final ImageServiceFacade imageServiceFacade;
+    private final PasswordEncoder photographerBCryptPasswordEncoder;
+    private final TokenService tokenService;
+    private final RedisTemplate<String, Token> redisTemplate;
+    private final PhotographerAuthenticationService photographerAuthenticationService;
     
     @Transactional
     public List<PhotographerListResponseDto> getPhotographerList(String region) {
@@ -96,7 +112,7 @@ public class PhotographerService {
         
         photographerRepository.save(Photographer.builder()
                 .accountId(photographerRequestDto.getAccountId())
-                .password(photographerRequestDto.getPassword())
+                .password(photographerBCryptPasswordEncoder.encode(photographerRequestDto.getPassword()))
                 .name(photographerRequestDto.getName())
                 .region(photographerRequestDto.getRegion())
                 .description(photographerRequestDto.getDescription())
@@ -108,31 +124,51 @@ public class PhotographerService {
     }
     
     @Transactional
-    public void authenticate(String username, String password) {
+    public TokenResponse authenticate(String username, String password) {
         
         Photographer photographer = photographerRepository.findByAccountId(username).orElseThrow(() ->
                 new ApiException(PhotographerErrorCode.PHOTOGRAPHER_NOT_FOUND));
-        
-        //인증 로직 필요
-        
+
+        if (photographerBCryptPasswordEncoder.matches(password, photographer.getPassword())) {
+            return issueTokenResponse(photographer);
+        } else {
+            throw new ApiException(MemberErrorCode.PASSWORD_NOT_MATCH);
+        }
+
     }
     
     @Transactional
     public PhotographerSingleResponseDto updatePhotographer(PhotographerUpdateDto photographerUpdateDto,
                                                             List<MultipartFile> images) {
-        
-        Photographer photographer = photographerRepository.findByAccountId(photographerUpdateDto.getAccountId()).orElseThrow(
-                () -> new ApiException(PhotographerErrorCode.PHOTOGRAPHER_NOT_FOUND));
-        
+
+        PhotographerSession principal = (PhotographerSession) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Photographer photographer = photographerRepository.findByAccountId(principal.getUsername())
+                .orElseThrow(() -> new ApiException(PhotographerErrorCode.UNAUTHORIZED));
+
+        redisTemplate.opsForHash().delete("photographer_refresh_token", photographer.getAccountId());
+
         //기존 이미지 삭제
         List<String> originImage = new ArrayList<>();
         originImage.add(photographer.getProfileImg());
         imageServiceFacade.deleteAllImagesFacade(originImage);
-        
+
         photographer.updatePhotographer(photographerUpdateDto, imageServiceFacade.uploadImageFacade(images));
-        
+
         List<RecentReviewsDto> reviews = photographerRepository.recentReviews(photographer.getId());
-        
+
+        TokenDto accessToken = tokenService.issuePhotographerAccessToken(photographer.getAccountId());
+        TokenDto refreshToken = tokenService.issuePhotographerRefreshToken(photographer.getAccountId());
+
+        TokenResponse tokenResponse = TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+        // 사진작가 정보 수정 후 UserDetails를 업데이트
+        PhotographerSession photographerSession = (PhotographerSession) photographerAuthenticationService.loadUserByUsername(photographerUpdateDto.getAccountId());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(photographerSession, null, photographerSession.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
         return PhotographerSingleResponseDto.builder()
                 .accountId(photographer.getAccountId())
                 .name(photographer.getName())
@@ -144,20 +180,36 @@ public class PhotographerService {
                 .ratingAvg(String.format("%.2f", ratingAverage(photographer.getReviews())))
                 .recentReviewDtos(reviews)
                 .careerYear(photographer.getCareerYear())
+                .tokenResponse(tokenResponse)
                 .build();
     }
     
     @Transactional
     public PhotographerSingleResponseDto updatePhotographer(PhotographerUpdateDto photographerUpdateDto) {
-        
-        Photographer photographer = photographerRepository.findByAccountId(photographerUpdateDto.getAccountId()).orElseThrow(
-                () -> new ApiException(PhotographerErrorCode.PHOTOGRAPHER_NOT_FOUND));
-        
+
+        PhotographerSession principal = (PhotographerSession) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Photographer photographer = photographerRepository.findByAccountId(principal.getUsername())
+                .orElseThrow(() -> new ApiException(PhotographerErrorCode.UNAUTHORIZED));
+        redisTemplate.opsForHash().delete("photographer_refresh_token", photographer.getAccountId());
+
         photographer.updatePhotographer(photographerUpdateDto);
-        
         List<RecentReviewsDto> reviews = photographerRepository.recentReviews(photographer.getId());
-        
+
+        TokenDto accessToken = tokenService.issuePhotographerAccessToken(photographer.getAccountId());
+        TokenDto refreshToken = tokenService.issuePhotographerRefreshToken(photographer.getAccountId());
+
+        TokenResponse tokenResponse = TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+        // 사진작가 정보 수정 후 UserDetails를 업데이트
+        PhotographerSession photographerSession = (PhotographerSession) photographerAuthenticationService.loadUserByUsername(photographer.getAccountId());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(photographerSession, null, photographerSession.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
         return PhotographerSingleResponseDto.builder()
+                // id는 만들어 놓고 안 넣으신 이유가 무엇인지..?
                 .accountId(photographer.getAccountId())
                 .name(photographer.getName())
                 .region(photographer.getRegion())
@@ -168,20 +220,30 @@ public class PhotographerService {
                 .ratingAvg(String.format("%.2f", ratingAverage(photographer.getReviews())))
                 .recentReviewDtos(reviews)
                 .careerYear(photographer.getCareerYear())
+                .tokenResponse(tokenResponse)
                 .build();
     }
     
     @Transactional
     public void deletePhotographer(String photographerId) {
-        
-        Photographer photographer = photographerRepository.findByAccountId(photographerId).orElseThrow(
-                () -> new ApiException(PhotographerErrorCode.PHOTOGRAPHER_NOT_FOUND));
-        
-        List<String> img = new ArrayList<>();
-        img.add(photographer.getProfileImg());
-        imageServiceFacade.deleteAllImagesFacade(img);
-        
-        photographerRepository.deleteByAccountId(photographerId);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        PhotographerSession principal = (PhotographerSession) authentication.getPrincipal();
+
+        Photographer photographer = photographerRepository.findByAccountId(principal.getUsername())
+                .orElseThrow(() -> new ApiException(MemberErrorCode.USER_NOT_FOUND));
+
+        if (photographer.getAccountId().equals(photographerId)){
+            List<String> img = new ArrayList<>();
+            img.add(photographer.getProfileImg());
+            imageServiceFacade.deleteAllImagesFacade(img);
+            photographerRepository.deleteByAccountId(photographerId);
+            redisTemplate.opsForHash().delete("photographer_refresh_token", photographerId);
+            SecurityContextHolder.clearContext();
+        }else {
+            throw new ApiException(MemberErrorCode.UNAUTHORIZED);
+        }
+
         
         /*
         단일 이미지 삭제 로직 구현 필요
@@ -198,6 +260,16 @@ public class PhotographerService {
             sum += review.getRating();
         }
         return sum / reviews.size();
+    }
+
+    private TokenResponse issueTokenResponse(Photographer photographer) {
+        TokenDto accessTokenDto = tokenService.issuePhotographerAccessToken(photographer.getAccountId());
+        TokenDto refreshTokenDto = tokenService.issuePhotographerRefreshToken(photographer.getAccountId());
+
+        return TokenResponse.builder()
+                .accessToken(accessTokenDto)
+                .refreshToken(refreshTokenDto)
+                .build();
     }
     
     

--- a/src/main/java/trendravel/photoravel_be/domain/token/service/TokenService.java
+++ b/src/main/java/trendravel/photoravel_be/domain/token/service/TokenService.java
@@ -6,9 +6,12 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import trendravel.photoravel_be.commom.error.ErrorCode;
 import trendravel.photoravel_be.commom.error.MemberErrorCode;
+import trendravel.photoravel_be.commom.error.PhotographerErrorCode;
 import trendravel.photoravel_be.commom.exception.ApiException;
 import trendravel.photoravel_be.db.member.MemberEntity;
+import trendravel.photoravel_be.db.photographer.Photographer;
 import trendravel.photoravel_be.db.respository.member.MemberRepository;
+import trendravel.photoravel_be.db.respository.photographer.PhotographerRepository;
 import trendravel.photoravel_be.domain.token.helper.TokenHelper;
 import trendravel.photoravel_be.db.inmemorydb.entity.Token;
 import trendravel.photoravel_be.domain.token.model.TokenDto;
@@ -24,6 +27,7 @@ public class TokenService {
 
     private final TokenHelper tokenHelper;
     private final MemberRepository memberRepository;
+    private final PhotographerRepository photographerRepository;
     private final RedisTemplate<String, Token> redisTemplate;
 
     public TokenDto issueAccessToken(String memberId) {
@@ -35,6 +39,7 @@ public class TokenService {
         data.put("name", member.getName());
         data.put("nickname", member.getNickname());
         data.put("memberId", member.getMemberId());
+        data.put("role", "member");
         data.put("issuer", "photoravel");
         return tokenHelper.issueAccessToken(data);
     }
@@ -47,6 +52,7 @@ public class TokenService {
         data.put("name", member.getName());
         data.put("nickname", member.getNickname());
         data.put("memberId", member.getMemberId());
+        data.put("role", "member");
         data.put("issuer", "photoravel");
         TokenDto refreshToken = tokenHelper.issueRefreshToken(  data);
         saveRefreshToken(refreshToken, member.getMemberId());
@@ -54,14 +60,36 @@ public class TokenService {
         return refreshToken;
     }
 
-    public String validationTokenWithEmail(String token){
+    public TokenDto issuePhotographerAccessToken(String accountId) {
+        Photographer photographer = photographerRepository.findByAccountId(accountId)
+                .orElseThrow(() -> new ApiException(PhotographerErrorCode.PHOTOGRAPHER_NOT_FOUND));
 
-        Map<String, Object> data = tokenHelper.validationTokenWithThrow(token);
-        Object userEmail = data.get("email");
-        Objects.requireNonNull(userEmail, () -> {
-            throw new ApiException(ErrorCode.NULL_POINT);
-        });
-        return userEmail.toString();
+        HashMap<String, Object> data = new HashMap<>();
+        data.put("accountId", photographer.getAccountId());
+        data.put("name", photographer.getName());
+        data.put("role", "photographer");
+        data.put("issuer", "photoravel");
+        return tokenHelper.issueAccessToken(data);
+    }
+
+    public TokenDto issuePhotographerRefreshToken(String accountId) {
+        Photographer photographer = photographerRepository.findByAccountId(accountId)
+                .orElseThrow(() -> new ApiException(PhotographerErrorCode.PHOTOGRAPHER_NOT_FOUND));
+
+        HashMap<String, Object> data = new HashMap<>();
+        data.put("accountId", photographer.getAccountId());
+        data.put("name", photographer.getName());
+        data.put("role", "photographer");
+        data.put("issuer", "photoravel");
+        TokenDto refreshToken = tokenHelper.issueRefreshToken(data);
+        savePhotographerRefreshToken(refreshToken, photographer.getAccountId());
+
+        return refreshToken;
+    }
+
+    public Map<String, Object> validationTokenWithMap(String token){
+
+        return tokenHelper.validationTokenWithThrow(token);
     }
 
     public String validationTokenWithMemberId(String token){
@@ -74,13 +102,34 @@ public class TokenService {
         return memberId.toString();
     }
 
+    public String validationTokenWithAccountId(String token){
+
+        Map<String, Object> data = tokenHelper.validationTokenWithThrow(token);
+        Object accountId = data.get("accountId");
+        Objects.requireNonNull(accountId, () -> {
+            throw new ApiException(ErrorCode.NULL_POINT);
+        });
+        return accountId.toString();
+    }
+
+
     public Token saveRefreshToken(TokenDto tokendto, String memberId) {
         Token token = Token.builder()
                 .id(memberId)
                 .refreshToken(tokendto.getToken())
                 .build();
 
-        redisTemplate.opsForHash().put("refresh_token", token.getId(), token);
+        redisTemplate.opsForHash().put("member_refresh_token", token.getId(), token);
+        return token;
+    }
+
+    public Token savePhotographerRefreshToken(TokenDto tokendto, String accountId) {
+        Token token = Token.builder()
+                .id(accountId)
+                .refreshToken(tokendto.getToken())
+                .build();
+
+        redisTemplate.opsForHash().put("photographer_refresh_token", token.getId(), token);
         return token;
     }
 

--- a/src/main/java/trendravel/photoravel_be/filter/JwtPhotographerAuthenticationFilter.java
+++ b/src/main/java/trendravel/photoravel_be/filter/JwtPhotographerAuthenticationFilter.java
@@ -1,0 +1,100 @@
+package trendravel.photoravel_be.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import trendravel.photoravel_be.commom.error.TokenErrorCode;
+import trendravel.photoravel_be.commom.exception.JwtException;
+import trendravel.photoravel_be.db.inmemorydb.entity.Token;
+import trendravel.photoravel_be.domain.authentication.service.PhotographerAuthenticationService;
+import trendravel.photoravel_be.domain.authentication.session.PhotographerSession;
+import trendravel.photoravel_be.domain.token.service.TokenService;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Order(3)
+public class JwtPhotographerAuthenticationFilter extends OncePerRequestFilter {
+
+    private final PhotographerAuthenticationService photographerAuthenticationService;
+    private final TokenService tokenService;
+    private final RedisTemplate<String, Token> redisTemplate;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        // 요청 URI를 가져옴
+        String path = request.getRequestURI();
+
+        // 인증이 필요한지 체크
+        if (!isAuthenticationRequired(path)) {
+            // 인증이 필요 없는 경우, 필터를 통과.
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = getToken(request);
+
+        // Authorization 헤더에 토큰이 있는지 확인
+        if (StringUtils.hasText(token)) {
+            String role = tokenService.validationTokenWithMap(token).get("role").toString();
+
+            if (role.equals("photographer")) {
+                String tokenAccountId = tokenService.validationTokenWithAccountId(token);
+                Token storedRefreshToken = (Token) redisTemplate.opsForHash().get("photographer_refresh_token", tokenAccountId);
+
+                // redis 에 저장된 refresh token이 있는지 확인
+                if (storedRefreshToken != null) {
+                    String storedAccountId = tokenService.validationTokenWithAccountId(storedRefreshToken.getRefreshToken());
+
+                    // refresh token payload의 memberId와 redis token의 memberId를 비교
+                    if (tokenAccountId.equals(storedAccountId)) {
+                        PhotographerSession photographerSession = (PhotographerSession) photographerAuthenticationService.loadUserByUsername(storedAccountId);
+
+                        // 인증 정보 생성 후
+                        // 인증 정보를 SecurityContextHolder 에 저장
+                        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(photographerSession, null, photographerSession.getAuthorities());
+                        usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+
+                        filterChain.doFilter(request, response);
+                    } else {
+                        throw new JwtException(TokenErrorCode.INVALID_TOKEN);
+                    }
+                } else {
+                    throw new JwtException(TokenErrorCode.REFRESH_TOKEN_NOT_VALID);
+                }
+            } else {
+                filterChain.doFilter(request, response);
+            }
+        } else {
+            throw new JwtException(TokenErrorCode.AUTHORIZATION_TOKEN_NOT_FOUND);
+        }
+    }
+
+    private String getToken(HttpServletRequest req){
+        String token = req.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return null;
+    }
+
+    private boolean isAuthenticationRequired(String path) {
+        // 인증이 필요 없는 경로를 정의
+        return !(path.startsWith("/public") || path.startsWith("/login") || path.startsWith("/swagger-ui") || path.startsWith("/v3/api-docs"));
+    }
+}


### PR DESCRIPTION
- 사진작가 인증, 인가
- 사진작가, 멤버 도메인간 접근 제어
- 멤버 약간의 리팩토링..

### 사진작가 인증

**로그인**
![image](https://github.com/user-attachments/assets/e62816c6-86a0-40f8-8418-ad43b5b2480c)
로그인시 토큰 발급

**액세스 토큰 재발급**
![image](https://github.com/user-attachments/assets/80f9aa18-7dde-42d5-8d6d-c27f60744578)
(redis에도 정상적으로 들어옵니다. 사진 생략)

**로그아웃**
![image](https://github.com/user-attachments/assets/240f73db-feb4-49b6-b768-ce7cffed665a)
(redis에도 정상적으로 삭제됩니다. 사진 생략)

### 사진작가, 멤버 도메인간 접근 제한

**사진작가 로그인 후 멤버 private 접근 시도시**
![image](https://github.com/user-attachments/assets/5351dc2e-b8fe-4285-935a-e93efba97791)
멤버 로그인 후 사진작가 private 접근 시도시에도 동일하게 403 포비든 띄웁니다.

> 그 외 자잘한 수정 사항은 생략하겠습니다..
이거 만드는데 진짜 너무 힘들었습니다...........ㅠ